### PR TITLE
fix: use YAML list syntax for allowed-tools

### DIFF
--- a/docs/skill-authoring-guide.md
+++ b/docs/skill-authoring-guide.md
@@ -20,7 +20,10 @@ Every skill has two parts: YAML frontmatter and a markdown body.
 ---
 name: my-skill-name
 description: One-line description explaining when to use this skill and what it produces.
-allowed-tools: Read, Write, Shell
+allowed-tools:
+  - Read
+  - Write
+  - Shell
 ---
 ```
 
@@ -368,7 +371,9 @@ description: >-
   to improve test quality, or before a major release. Do not use
   for writing tests (use a test-writing skill instead) or for
   linting/style checks.
-allowed-tools: Read, Shell
+allowed-tools:
+  - Read
+  - Shell
 ---
 ```
 

--- a/plugins/trogonstack-ask/skills/ask-question/SKILL.md
+++ b/plugins/trogonstack-ask/skills/ask-question/SKILL.md
@@ -5,7 +5,10 @@ description: >-
   clarification. Each question includes the intention behind it and current
   assumptions. Use when the user wants to be interviewed about a topic, gather
   requirements, or needs help thinking through a problem step by step.
-allowed-tools: Read, Write, AskUserQuestion
+allowed-tools:
+  - Read
+  - Write
+  - AskUserQuestion
 ---
 
 # Ask Question

--- a/plugins/trogonstack-datadog/skills/datadog-design-dashboard/SKILL.md
+++ b/plugins/trogonstack-datadog/skills/datadog-design-dashboard/SKILL.md
@@ -10,7 +10,11 @@ description: >-
   Do not use for: (1) Datadog agent installation or configuration,
   (2) monitor/alert rule design, (3) APM instrumentation or tracing setup,
   (4) log pipeline configuration.
-allowed-tools: AskUserQuestion, Write, Read, Shell
+allowed-tools:
+  - AskUserQuestion
+  - Write
+  - Read
+  - Shell
 ---
 
 # Design Datadog Dashboard

--- a/plugins/trogonstack-diataxis/skills/diataxis-gen-readme/SKILL.md
+++ b/plugins/trogonstack-diataxis/skills/diataxis-gen-readme/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: diataxis-gen-readme
 description: Generate a README introduction following the Diataxis 4-paragraph structure for product documentation.
-allowed-tools: Read, Write
+allowed-tools:
+  - Read
+  - Write
 ---
 
 Generate a README introduction following this 4-paragraph structure, replacing the placeholder text with content specific to the product:

--- a/plugins/trogonstack-diataxis/skills/diataxis-organize-docs/SKILL.md
+++ b/plugins/trogonstack-diataxis/skills/diataxis-organize-docs/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: diataxis-organize-docs
 description: Reorganize documentation into the Diataxis framework structure. Splits existing docs into tutorials, how-to guides, reference, and explanation sections.
-allowed-tools: Read, Write
+allowed-tools:
+  - Read
+  - Write
 ---
 
 # Diataxis Documentation Organization

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-applying-conways-law/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-applying-conways-law/SKILL.md
@@ -6,7 +6,9 @@ description: >-
   after defining inputs/outputs. Do not use for: planning feature slice
   implementation order (use eventmodeling-slicing-event-models) or defining
   command/read model boundaries (use eventmodeling-designing-event-models).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Applying Conway's Law

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-brainstorming-events/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-brainstorming-events/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   events in sequence (use eventmodeling-plotting-events), designing commands
   or read models (use eventmodeling-designing-event-models), or when a complete
   event list already exists.
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Brainstorming Events

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-checking-completeness/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-checking-completeness/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   all scenarios defined. Do not use for: architectural validation against event sourcing
   principles (use eventmodeling-validating-event-models) or elaborating
   Given-When-Then specs (use eventmodeling-elaborating-scenarios).
-allowed-tools: Write
+allowed-tools:
+  - Write
 ---
 
 # Checking Completeness

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-designing-event-models/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-designing-event-models/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   scratch (use eventmodeling-brainstorming-events), optimizing stream sizing
   or snapshotting (use eventmodeling-optimizing-stream-design), or translating
   external system events (use eventmodeling-translating-external-events).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Designing Event Models

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-elaborating-scenarios/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-elaborating-scenarios/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   architectural validation (use eventmodeling-validating-event-models) or
   verifying field completeness across the model (use
   eventmodeling-checking-completeness).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Elaborating Scenarios

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-identifying-inputs/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-identifying-inputs/SKILL.md
@@ -6,7 +6,9 @@ description: >-
   Do not use for: identifying read models or outputs (use
   eventmodeling-identifying-outputs) or elaborating behavior specifications
   (use eventmodeling-elaborating-scenarios).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Identifying Inputs

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-identifying-outputs/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-identifying-outputs/SKILL.md
@@ -5,7 +5,9 @@ description: >-
   what data flows back to UI and Processors. Use after defining inputs. Do not
   use for: identifying commands or inputs (use eventmodeling-identifying-inputs)
   or verifying field completeness (use eventmodeling-checking-completeness).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Identifying Outputs

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-integrating-legacy-systems/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-integrating-legacy-systems/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   existing legacy constraints (use eventmodeling-orchestrating-event-modeling)
   or translating inbound events from external APIs (use
   eventmodeling-translating-external-events).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Integrating Legacy Systems

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-optimizing-stream-design/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-optimizing-stream-design/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   stream design before implementation. Do not use for: designing the initial
   event model structure (use eventmodeling-designing-event-models) or
   general architectural validation (use eventmodeling-validating-event-models).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Optimizing Stream Design

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-orchestrating-event-modeling/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-orchestrating-event-modeling/SKILL.md
@@ -9,7 +9,9 @@ description: >-
   eventmodeling-elaborating-scenarios for Step 7), validating an
   already-completed model (use eventmodeling-validating-event-models), or
   modernizing legacy systems (use eventmodeling-integrating-legacy-systems).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Orchestrating Event Modeling

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-plotting-events/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-plotting-events/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   brainstorming events. Do not use for: brainstorming new events (use
   eventmodeling-brainstorming-events) or designing command/read model
   architecture (use eventmodeling-designing-event-models).
-allowed-tools: Write
+allowed-tools:
+  - Write
 ---
 
 # Plotting Events

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-slicing-event-models/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-slicing-event-models/SKILL.md
@@ -9,7 +9,9 @@ description: >-
   eventmodeling-applying-conways-law) or planning before the event model is
   complete (complete the full model first using
   eventmodeling-orchestrating-event-modeling).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Slicing Event Models

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-storyboarding-events/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-storyboarding-events/SKILL.md
@@ -6,7 +6,9 @@ description: >-
   after sequencing events. Do not use for: identifying commands or processor
   actions (use eventmodeling-identifying-inputs) or designing read models
   (use eventmodeling-identifying-outputs).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Storyboarding Events

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-translating-external-events/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-translating-external-events/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   modernizing legacy systems using the side-car pattern (use
   eventmodeling-integrating-legacy-systems) or designing command handlers for
   the translated events (use eventmodeling-designing-event-models).
-allowed-tools: AskUserQuestion, Write
+allowed-tools:
+  - AskUserQuestion
+  - Write
 ---
 
 # Translating External Events

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-validating-event-models-checklist/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-validating-event-models-checklist/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   completing event modeling steps. Do not use for: reviewing incomplete or
   in-progress models (use eventmodeling-validating-event-models), or for
   elaborating new scenarios (use eventmodeling-elaborating-scenarios).
-allowed-tools: Write
+allowed-tools:
+  - Write
 ---
 
 # Event Model Validation Checklist Skill

--- a/plugins/trogonstack-eventmodeling/skills/eventmodeling-validating-event-models/SKILL.md
+++ b/plugins/trogonstack-eventmodeling/skills/eventmodeling-validating-event-models/SKILL.md
@@ -8,7 +8,8 @@ description: >-
   code generation. Do not use for: the structured 23-check production checklist
   (use eventmodeling-validating-event-models-checklist) or field-level
   completeness verification (use eventmodeling-checking-completeness).
-allowed-tools: Write
+allowed-tools:
+  - Write
 ---
 
 # Validating Event Models

--- a/plugins/trogonstack-nats/skills/nats-design-subject/SKILL.md
+++ b/plugins/trogonstack-nats/skills/nats-design-subject/SKILL.md
@@ -9,7 +9,11 @@ description: >-
   setup, (2) client library implementation or connection code, (3) debugging
   connectivity or performance issues, (4) choosing between NATS and other
   messaging systems.
-allowed-tools: AskUserQuestion, Write, Read, Shell
+allowed-tools:
+  - AskUserQuestion
+  - Write
+  - Read
+  - Shell
 ---
 
 # Design NATS Subject Hierarchy

--- a/plugins/trogonstack-otel/skills/otel-name-metric/SKILL.md
+++ b/plugins/trogonstack-otel/skills/otel-name-metric/SKILL.md
@@ -7,7 +7,11 @@ description: >-
   metric naming consistency. Do not use for: (1) span or trace naming, (2) OTel
   collector configuration, (3) SDK installation or setup, (4) alerting or
   dashboard design.
-allowed-tools: AskUserQuestion, Write, Read, Shell
+allowed-tools:
+  - AskUserQuestion
+  - Write
+  - Read
+  - Shell
 ---
 
 # Review or Create OpenTelemetry Metric Names

--- a/plugins/trogonstack-otel/skills/otel-name-span/SKILL.md
+++ b/plugins/trogonstack-otel/skills/otel-name-span/SKILL.md
@@ -7,7 +7,11 @@ description: >-
   or auditing span naming consistency. Do not use for: (1) metric naming, (2)
   OTel collector configuration, (3) SDK installation or setup, (4) alerting or
   dashboard design.
-allowed-tools: AskUserQuestion, Write, Read, Shell
+allowed-tools:
+  - AskUserQuestion
+  - Write
+  - Read
+  - Shell
 ---
 
 # Review or Create OpenTelemetry Span Names


### PR DESCRIPTION
## Summary

- The `allowed-tools` frontmatter field only accepts a space-separated string or a YAML list; comma-separated strings were neither and risked being parsed as a single tool name with commas.