### PR TITLE
feat(product-requirements): introduce PRD and FRD authoring skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,6 +54,12 @@
       "description": "Event-driven architecture skills for designing event names, schemas, contracts, and catalogs following good practices for domain and integration events",
       "source": "./plugins/trogonstack-eda",
       "category": "development"
+    },
+    {
+      "name": "trogonstack-product-requirements",
+      "description": "Skills for writing and reviewing Product Requirements Documents (PRDs) and Feature Requirements Documents (FRDs)",
+      "source": "./plugins/trogonstack-product-requirements",
+      "category": "development"
     }
   ]
 }

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -47,6 +47,9 @@
     },
     "plugins/trogonstack-eda": {
       "component": "trogonstack-eda"
+    },
+    "plugins/trogonstack-product-requirements": {
+      "component": "trogonstack-product-requirements"
     }
   },
   "plugins": [

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -6,5 +6,6 @@
   "plugins/trogonstack-ask": "0.1.2",
   "plugins/trogonstack-otel": "0.1.1",
   "plugins/trogonstack-eventmodeling": "0.1.1",
-  "plugins/trogonstack-eda": "0.1.1"
+  "plugins/trogonstack-eda": "0.1.1",
+  "plugins/trogonstack-product-requirements": "0.0.1"
 }

--- a/plugins/trogonstack-product-requirements/.claude-plugin/plugin.json
+++ b/plugins/trogonstack-product-requirements/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trogonstack-product-requirements",
-  "description": "Skills for writing and reviewing Product Requirements Documents (PRDs)",
+  "description": "Skills for writing and reviewing Product Requirements Documents (PRDs) and Feature Requirements Documents (FRDs)",
   "version": "0.0.1",
   "author": {
     "name": "TrogonStack",

--- a/plugins/trogonstack-product-requirements/.claude-plugin/plugin.json
+++ b/plugins/trogonstack-product-requirements/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "trogonstack-product-requirements",
+  "description": "Skills for writing and reviewing Product Requirements Documents (PRDs)",
+  "version": "0.0.1",
+  "author": {
+    "name": "TrogonStack",
+    "url": "https://github.com/TrogonStack"
+  }
+}

--- a/plugins/trogonstack-product-requirements/README.md
+++ b/plugins/trogonstack-product-requirements/README.md
@@ -1,0 +1,76 @@
+# Product Requirements
+
+Skills for writing and reviewing product-level and feature-level requirements. All artifacts live under `.trogonai/project/{projectid}/`.
+
+## Requirements Operating Model
+
+These skills operate on the Requirements side of the product development flow:
+
+- **Requirements** own product-level context, feature requirements, and the feature hierarchy.
+- **Blueprints** own high-level architecture, runtime design, and code links.
+- **Work Orders** own implementable delivery slices and planning phases.
+
+Shared behavior for module boundaries, source-of-truth checks, clarification, feature hierarchy, and downstream impact lives in the `requirements-operating-model` skill. When the TrogonStack `ask-question` skill is available, use it for clarification sessions; these skills keep the Product Requirements-specific judgment about what needs to be clarified.
+
+| Skill | Purpose |
+|-------|---------|
+| `requirements-operating-model` | Shared Requirements-module boundaries, clarification pattern, source-of-truth rules, feature hierarchy, and downstream-impact guidance |
+
+## Product Overview Documents
+
+Product Overview Documents capture the high-level **why** and **what** for the entire product.
+
+- The **why** is the business motivation: the problems being solved, the KPIs not being met, the North Star goals the business is pursuing.
+- The **what** is the product description: what the product is and how its parts fit together.
+
+These documents give anyone (executive, product manager, or engineer) the context they need before looking at specific features.
+
+The six default files live under `.trogonai/project/{projectid}/prd/`:
+
+| Concern | Skill | File |
+|---------|-------|------|
+| Why: problems being solved | `prd-business-problem` | `business-problem.prd.md` |
+| Why: status quo being improved | `prd-current-state` | `current-state.prd.md` |
+| Why: who it serves and what success means for them | `prd-personas` | `personas.prd.md` |
+| What: the product and how its parts fit together | `prd-product-description` | `product-description.prd.md` |
+| Why: the KPIs / North Star being pursued | `prd-success-metrics` | `success-metrics.prd.md` |
+| What: the technical constraints the product must meet | `prd-technical-requirements` | `technical-requirements.prd.md` |
+| Custom: product-level context beyond the defaults | `prd-custom-overview` | `{slug}.prd.md` |
+| Audit of all of the above | `prd-review` | `review.prd.md` |
+
+Each section skill has a focused document owner, but the set is not isolated. Later documents should read the earlier context they depend on, and reviews should flag source-of-truth conflicts across the set.
+
+Additional Product Overview Documents are created with `prd-custom-overview` when the six defaults do not cover a product-specific context area. Custom documents still explain product-level **why** or **what** in plain language; they must name their relationship to the defaults or other custom overviews so they do not become miscellaneous buckets. Feature behavior belongs in FRDs.
+
+## Feature Requirements Documents
+
+Feature Requirements Documents (FRDs) capture the localized **why** and **what** for a single feature: what engineers actually pick up to build.
+
+- The **why** is the user story: *"As a \<role\>, I want to \<action\>, so that I can \<outcome\>."*
+- The **what** is the acceptance criteria: *"When \<condition\>, the system shall/should/may \<behavior\>."*
+
+Each FRD follows the same three-section template (**Overview**, **Terminology**, **Requirements**) with stable IDs so they can be referenced unambiguously from code, commits, tickets, tests, and reviews. Cross-requirement behavior should usually be captured as acceptance criteria; `Child FRDs` is the standard built-in extension for parent documents with nested children.
+
+- **`REQ-`** = **Requirement**: one cohesive, independently testable capability. Format: `REQ-[PREFIX]-NNN`.
+- **`AC-`** = **Acceptance Criterion**: one observable behavior the system must exhibit. Format: `AC-[PREFIX]-NNN.N`, where `NNN` matches the parent requirement.
+
+Large features nest as parent + children, where the parent delivers value on its own and the child is meaningless without the parent.
+
+Files live under `.trogonai/project/{projectid}/frd/`:
+
+- Top-level: `{slug}.frd.md`
+- Parent with children: `{parent-slug}/index.frd.md` + `{parent-slug}/{child-slug}.frd.md`
+
+| Skill | Purpose |
+|-------|---------|
+| `frd-getting-started` | Produce the initial set of FRDs for a new project, calibrated agile vs waterfall |
+| `frd-write` | Author or refine a single FRD |
+| `frd-split` | Split, merge, or nest FRDs using the parent-delivers-value rule |
+| `frd-review` | Audit a single FRD or a tree of FRDs |
+
+## Installation
+
+```bash
+claude plugin marketplace add TrogonStack/agentskills
+claude plugin install trogonstack-product-requirements@TrogonStack
+```

--- a/plugins/trogonstack-product-requirements/skills/frd-getting-started/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-getting-started/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: frd-getting-started
+description: Produce the initial set of Feature Requirements Documents (FRDs) for a new project. Calibrates between an agile first pass (small set of must-have features only) and a waterfall first pass (comprehensive coverage). Asks how many features to draft, identifies them from the project's product overview, and scaffolds each via the FRD template. Use when the user is starting a project and there are no FRDs yet.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Glob
+  - Grep
+---
+
+# FRD Getting Started: Initial Feature Set
+
+## Purpose
+
+Projects are not seeded with any default FRDs. This skill walks the user through producing the **initial set** of FRDs once, calibrated to how the user wants to work.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before translating Product Overview Documents into FRDs. Use its clarification pattern for ambiguous feature boundaries, and follow its source-of-truth and downstream-impact rules.
+
+## When to Use
+
+- A project has been created and `.trogonai/project/{projectid}/frd/` is empty
+- The user wants to plan a chunk of features in one pass rather than drafting them ad-hoc
+- The user has just produced the Product Overview Documents (`prd-*` files) and wants to translate them into the first FRDs
+
+## Resolve Project
+
+1. Determine `projectid` (ask if not supplied; offer choices via `Glob`).
+2. `Glob` `.trogonai/project/{projectid}/frd/**/*.frd.md`: if any FRDs already exist, stop and direct the user to `frd-write`. This skill is for getting started only, not for extending an established set.
+3. Read whichever of these files exist for context, in priority order:
+   - `personas.prd.md` (roles for user stories)
+   - `product-description.prd.md` (the surfaces and components to translate into features)
+   - `business-problem.prd.md`, `success-metrics.prd.md` (to prioritize)
+   - `current-state.prd.md`, `technical-requirements.prd.md` (to catch status-quo scope and constraints)
+
+If the Product Overview is missing, surface that as a finding and ask whether to proceed or run the relevant `prd-*` skills first.
+
+## Calibrate the Pass
+
+Ask the user how they want to work this first time. Offer two anchors and let them pick or land somewhere in between:
+
+- **Agile first pass**: draft only the **2–4 must-have features** that prove the product can deliver its primary outcome metric. Other features are deferred to later passes.
+- **Waterfall first pass**: draft **every feature visible in the Product Description** before any one is built, so engineering can plan and estimate the whole scope.
+
+Then ask:
+
+- Approximate number of FRDs for this pass (the calibration sets a default; the user can override).
+- Whether sub-features should be drafted now, or deferred until the parent is built (`frd-split` can do this later).
+
+## Identify the Feature Set
+
+Use the Product Description's components and surfaces as the candidate list. For each candidate, ask:
+
+- Does this pass the **feature unit** definition: one cohesive, independently-buildable capability with a clear user-facing value?
+- Is it top-level, or a child of another candidate? Apply the parent-delivers-value rule: parents must work without the child; children must be meaningless without the parent.
+
+Group candidates into:
+
+- **This pass** (in-scope for getting started)
+- **Later passes** (deferred)
+- **Not a feature** (cross-cutting concerns, non-functional requirements: these belong in `technical-requirements.prd.md`)
+
+Read the grouping back to the user and get explicit confirmation before scaffolding.
+
+## Scaffold the FRDs
+
+For each feature in **this pass**, scaffold a file at:
+
+- Top-level → `.trogonai/project/{projectid}/frd/{slug}.frd.md`
+- Child → if the initial pass includes children, write the parent directly as `{parent}/index.frd.md` and write children as `{parent}/{slug}.frd.md`
+
+Each scaffold is a **stub**, not a finished FRD. It contains:
+
+- Title, project, prefix, parent reference, status `Stub`, last-updated.
+- A placeholder Overview noting what the feature is meant to cover (one sentence, taken from the Product Description).
+- An empty Terminology section.
+- A placeholder requirement `REQ-{PREFIX}-001: <to be authored>` with no acceptance criteria, marked `Status: pending`.
+
+After scaffolding, list the files and recommend the user run `frd-write` per feature to fill in the actual requirements. Do **not** try to fully author every FRD here; that loses the per-feature discovery quality.
+
+### Prefix assignment
+
+For each top-level scaffold, ask the user to confirm a 2–4 letter prefix derived from the feature name. `Grep` existing files in the project to ensure uniqueness. For children, the prefix is `{parent-prefix}-{sub}` per the standard rule.
+
+## Stub Template
+
+```markdown
+# <Feature Name>
+
+- **Project:** {projectid}
+- **Prefix:** {PREFIX}
+- **Parent FRD:** <relative path or "none (top-level)">
+- **Status:** Stub
+- **Last updated:** <YYYY-MM-DD>
+
+## Overview
+
+<One-sentence placeholder taken from the Product Description. Author with `frd-write` to expand into the full 1–2 paragraph overview.>
+
+## Terminology
+
+<To be authored.>
+
+## Requirements
+
+### REQ-{PREFIX}-001: <to be authored>
+
+**Status:** pending
+
+**User Story:** <author with `frd-write`>
+
+**Acceptance Criteria:**
+- <author with `frd-write`>
+
+```
+
+The canonical shape comes from the project's Feature Requirements Template when available. Otherwise, use the bundled default at `../frd-write/assets/frd-template.md`. The stub above is the abbreviated form for scaffolding; `frd-write` expands it into the full template.
+
+## Output Summary
+
+After scaffolding, write `.trogonai/project/{projectid}/frd/_getting-started.md` summarizing the pass:
+
+```markdown
+# Getting Started: Initial FRD Set
+
+- **Project:** {projectid}
+- **Date:** <YYYY-MM-DD>
+- **Pass style:** <Agile / Waterfall / Custom>
+- **Features in this pass:** <N>
+- **Features deferred:** <N>
+
+## This Pass
+- [{slug}](./{slug}.frd.md): <one-line>
+- [{parent-slug}/{child-slug}](./{parent-slug}/{child-slug}.frd.md): <one-line; nested under parent-slug>
+
+## Deferred to Later Passes
+- <feature>: <one-line; why deferred>
+
+## Not a Feature (re-homed elsewhere)
+- <item>: belongs in <prd file or other location>
+
+## Next Steps
+1. Run `frd-write` per stub to author the full FRD.
+2. Run `frd-review` once a meaningful chunk is authored.
+3. Run `frd-split` if a feature grows beyond ~5 requirements.
+```
+
+## Quality Bar
+
+The pass is complete when:
+
+- Every feature in this pass has a stub file with prefix, parent reference, and a placeholder REQ-001.
+- Parents and children follow the parent-delivers-value rule.
+- A summary file enumerates the pass, deferrals, and non-features.
+- The user has explicit next steps (which `frd-write` calls come next).
+
+## Anti-Patterns to Reject
+
+- Trying to fully author every FRD in one pass; that bypasses per-feature discovery.
+- Scaffolding "every component" without applying the feature-unit definition.
+- Scaffolding sub-features whose parents have not been scaffolded.
+- Re-running this skill against a project that already has FRDs; use `frd-write` instead.
+
+## Related Skills
+
+- `frd-write`: author the full content of each scaffolded FRD
+- `frd-split`: decompose a feature that turns out to be an umbrella
+- `frd-review`: audit once a pass of authoring is done
+- `prd-product-description`: re-check if the candidate feature list reveals product-shape gaps
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive calibration and feature grouping
+- **Read**: load Product Overview files for context
+- **Write**: scaffold stub FRDs and the getting-started summary
+- **Glob**: verify the project is empty of FRDs and list candidates

--- a/plugins/trogonstack-product-requirements/skills/frd-review/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-review/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: frd-review
+description: Review Feature Requirements Documents (FRDs) (single file or full tree) against the Overview / Terminology / Requirements template, source-of-truth rules, module boundaries, downstream impact, and the parent-delivers-value rule for sub-features. Writes a review file. Use when the user asks to review, audit, or sanity-check a feature spec.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Glob
+  - Grep
+---
+
+# FRD: Review a Feature Requirements Document
+
+## Purpose
+
+Audit an FRD (or a parent + its nested children) the way an experienced engineer or product lead would in planning: surface the gaps that cause estimation churn, rework after implementation, or bugs found in QA.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before reviewing. Use it to check module boundaries, source-of-truth conflicts, feature hierarchy, and downstream Blueprint / Work Order impact.
+
+## When to Use
+
+- An FRD draft needs a sanity check before engineering picks it up
+- A parent FRD with children needs to be audited as a tree
+- A reviewer wants a second pass on someone else's feature spec
+
+## Resolve the Target
+
+1. Determine `projectid` (ask if not supplied; offer choices via `Glob`).
+2. Resolve what to review:
+   - A specific FRD path → review just that file.
+   - A directory (parent with children) → review the parent's `index.frd.md` plus every `*.frd.md` sibling.
+   - "Everything under this project" → glob `.trogonai/project/{projectid}/frd/**/*.frd.md`.
+3. If `personas.prd.md` exists in the project, read it: user stories should reference its personas.
+
+## Per-FRD Checklist
+
+For each FRD, run every item and mark **Pass**, **Gap**, **Risk**, or **N/A** with a one-line justification.
+
+### 1. Overview
+- [ ] One or two narrative paragraphs (not a bullet list)
+- [ ] Describes what the feature does and why users need it
+- [ ] Focuses on problem solved and value delivered, not implementation mechanisms
+- [ ] A stakeholder could understand the feature in under a minute
+
+### 2. Terminology
+- [ ] Only feature-specific terms are defined
+- [ ] No industry-standard or obvious terms (e.g., "API", "user") are defined
+- [ ] Definitions are brief and precise
+- [ ] If absent, the absence is justified (no ambiguous terms exist)
+
+### 3. Requirements: structure
+- [ ] Each requirement uses the id format `REQ-{PREFIX}-NNN: Title`
+- [ ] Prefix matches the FRD's declared prefix (and parent-prefix-{sub} for children)
+- [ ] Sequence numbers are zero-padded to three digits and unique within the file
+- [ ] Each requirement has a single-sentence user story in `As a [role], I want to [action], so that I can [outcome].` form
+- [ ] Role is a concrete persona (and matches `personas.prd.md` if present)
+- [ ] At least one acceptance criterion per requirement
+
+### 4. Acceptance Criteria: content
+- [ ] Each AC uses id format `AC-{PREFIX}-NNN.N` matching its requirement
+- [ ] Each AC begins with `When [condition],` followed by `the system shall/should/may [behavior].`
+- [ ] Modal verbs are correctly used: **shall** = mandatory, **should** = recommended, **may** = optional
+- [ ] Each AC is atomic (one behavior, not compound)
+- [ ] Each AC is testable: clear enough to write a test against
+- [ ] Each requirement has at least one happy-path AC and at least one failure / edge-case AC
+
+### 5. Optional Extension Sections
+- [ ] `Child FRDs`, if present, matches the actual child files and summarizes their user-facing enhancement
+- [ ] Any other extension section is defined by the project's Feature Requirements Template
+- [ ] Extension sections do not prescribe UI, screens, user flows, or implementation details
+- [ ] Cross-requirement behavior is captured as acceptance criteria whenever possible
+- [ ] Empty or placeholder extension sections are absent
+
+### 6. Cross-cutting hygiene
+- [ ] Project, prefix, parent reference, status, last-updated present
+- [ ] Parent reference (if any) points to a file that exists
+- [ ] No "TBD" left unowned
+- [ ] Adjective-only behaviors ("appropriately", "correctly", "smoothly", "fast") flagged
+
+## Cross-FRD Checks (parent + children)
+
+When reviewing a tree:
+
+- [ ] Every child's requirements describe an enhancement, not a dependency the parent needs to function
+- [ ] **Parent-delivers-value rule:** removing any child file would leave the parent still passing the feature-unit definition
+- [ ] **Child-meaningless-without-parent rule:** each child only makes sense as part of the parent's scope
+- [ ] Child prefixes are `{parent-prefix}-{sub}` and the sub-prefix is unique among siblings
+- [ ] No requirement id collides anywhere in the tree
+- [ ] Parent's `## Child FRDs` list matches the actual files on disk
+- [ ] No "misc" or "other" child (suggests the split axis was wrong)
+- [ ] Personas referenced across siblings are consistent with `personas.prd.md`
+
+## Operating Model Checks
+
+- [ ] Feature requirements do not contain Blueprint-owned architecture or Work Order-owned delivery tasks
+- [ ] FRD user stories and ACs can be traced to Product Overview context or explicit user input
+- [ ] Requirement changes likely to affect Blueprints or Work Orders are called out for downstream follow-up
+- [ ] Open questions use the shared clarification pattern when they block engineering readiness
+
+## Output
+
+Write the review to:
+
+- Single FRD: `.trogonai/project/{projectid}/frd/{slug}.review.md`
+- Tree: `.trogonai/project/{projectid}/frd/{parent-slug}/_review.md`
+- Whole project: `.trogonai/project/{projectid}/frd/_review.md`
+
+Template:
+
+```markdown
+# FRD Review
+
+- **Project:** {projectid}
+- **Scope:** <single FRD path | parent + N children | whole project>
+- **Reviewed:** <YYYY-MM-DD>
+- **Overall verdict:** <Ready / Ready with revisions / Not ready>
+
+## Top Findings
+1. <highest-impact gap or risk>
+2. <next>
+3. <next>
+
+## Per-FRD Results
+
+### <path/to/feature.frd.md>
+- Overview: Pass / Gap: <one line>
+- Terminology: Pass / Gap: <one line>
+- Requirements structure: Pass / Gap: <one line, cite any bad ids>
+- Acceptance criteria: Pass / Gap: <one line, cite the worst offender as REQ/AC id>
+- Optional extension sections: Pass / Gap / N/A: <one line>
+- Hygiene: Pass / Gap: <one line>
+
+<repeat for each FRD reviewed>
+
+## Cross-FRD Findings (if tree)
+- Parent-delivers-value rule: Pass / Gap: <one line>
+- Child-meaningless-without-parent rule: Pass / Gap: <one line>
+- ID collisions: <none / cite>
+- Child FRDs list consistency: Pass / Gap
+
+## Operating Model and Downstream Impact
+- Source of truth: Pass / Gap / Risk: <one line>
+- Module boundaries: Pass / Gap / Risk: <one line>
+- Likely downstream follow-up: <none / affected Blueprints or Work Orders by human-readable name>
+
+## Required Revisions (blockers)
+- <must fix before engineering picks up>: fix with `frd-write` or `frd-split`
+
+## Recommended Revisions (non-blockers)
+- <should fix, not blocking>: fix with `<skill>`
+
+## Suggested Questions for the Author
+- <question that exposes an assumption>
+```
+
+If a previous review file exists at the same path, overwrite it.
+
+## Verdict Rubric
+
+- **Ready**: no gaps in Requirements structure or Acceptance Criteria; overview clear; optional extension sections are either useful or absent; sub-feature rules satisfied. Minor wording only.
+- **Ready with revisions**: gaps exist but fix path is clear. For each gap, name the section / requirement and the skill (`frd-write` or `frd-split`) that fixes it.
+- **Not ready**: user stories are generic ("As a user, I want X"), ACs are untestable ("handled appropriately"), or sub-features violate the parent-value rules. Engineering cannot estimate or build from this as-is.
+
+## Key Principles
+
+- **Surface gaps, do not rewrite.** Point to what is missing and why it matters.
+- **Cite the id.** Every finding references the specific `REQ-...` or `AC-...` it came from.
+- **Distinguish blockers from polish.** Required vs recommended must be obvious.
+- **Recommend the fix path.** Each gap maps to `frd-write` (refine) or `frd-split` (restructure).
+
+## Related Skills
+
+- `frd-write`: author or refine a single FRD
+- `frd-split`: restructure FRDs by splitting, merging, or nesting
+- `frd-getting-started`: produce the initial set of FRDs
+- `prd-review`: companion overview-level review
+
+## Allowed Tools
+
+- **AskUserQuestion**: resolve project and target if not supplied
+- **Read**: load each FRD and the project's personas
+- **Write**: write the review file
+- **Glob / Grep**: locate FRDs, detect adjective-only ACs, check id collisions

--- a/plugins/trogonstack-product-requirements/skills/frd-split/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-split/SKILL.md
@@ -79,7 +79,7 @@ Before writing, read back every requirement and where it lands. Get explicit con
 
 After a SPLIT or NEST under a parent:
 
-```
+```text
 .trogonai/project/{projectid}/frd/{parent-slug}/
 ├── index.frd.md
 ├── {child-1-slug}.frd.md

--- a/plugins/trogonstack-product-requirements/skills/frd-split/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-split/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: frd-split
+description: Split, merge, or nest Feature Requirements Documents (FRDs) using the parent-delivers-value rule where a parent feature must deliver value on its own and a child must be meaningless without the parent. Promotes parent files into directories, scaffolds child FRDs with appended prefixes, and rewrites the parent into an umbrella. Use when an FRD has grown too large or when multiple FRDs should be combined.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash(rm:*)
+---
+
+# FRD: Split, Merge, or Nest Features
+
+## Purpose
+
+Restructure FRDs so each one passes the **feature unit** test: it delivers cohesive value, has a single owner, and can be planned independently.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before restructuring. This skill changes the feature hierarchy, so apply the source-of-truth, clarification, and downstream-impact rules before writing files.
+
+## The Decision Rule
+
+Apply these three options strictly:
+
+- **Split into separate top-level features** when each resulting piece passes the feature unit definition on its own, or when different roles own different parts.
+- **Merge / keep in one feature** when the pieces' requirements break without each other, they complete one task together, or they are describable in one sentence.
+- **Nest as a child feature** when the parent already delivers value on its own, the child enhances but is not required, and the child is meaningless without the parent.
+
+> Example: "Search" finds items by keyword: complete on its own. "Search Filters" adds faceted filtering. Search works without filters; filters need search. → **Nest** Search Filters under Search.
+
+If a candidate child *would break the parent if removed*, it is not a child. It is part of the parent (merge), or it is its own top-level feature (split).
+
+## When to Use
+
+- An FRD has more than roughly 5–7 requirements
+- A reviewer flagged an FRD as overscoped
+- Two FRDs duplicate or depend on each other and should be reconciled
+- A feature is naturally an umbrella with optional enhancements (e.g., User Management with User Roles, Groups, Audit Log)
+
+## Resolve Project and Targets
+
+1. Determine `projectid` (ask if not supplied; offer choices via `Glob`).
+2. Identify the FRD(s) to restructure. If a single FRD is being split, locate it via `Glob`. If multiple FRDs are being reconciled, list them all.
+3. Read every target file in full before proposing changes: no requirement may be dropped silently.
+
+## Discovery
+
+### 1. Decide the operation
+
+Ask the user, given the targets, which operation applies. Use the decision rule above; do not let the user pick "nest" for something that violates the parent-delivers-value test.
+
+### 2. For a SPLIT or NEST: identify each resulting feature
+
+For each new child or split-out feature:
+
+- **Slug**: kebab-case, scoped to the parent if a child (e.g., parent `user-management` → child `user-roles`).
+- **Sub-prefix** (children only): 2–3 letters appended to the parent's prefix. Confirm uniqueness against siblings (`Grep` existing FRDs for `REQ-{parent-prefix}-{sub}-`).
+- **One-line summary**.
+- **Which parent requirements move here**: every existing `REQ-...` in the parent must be assigned to exactly one resulting feature, or explicitly retained in the umbrella. No requirement is dropped.
+- **Parent-value check** (children only): confirm the parent still passes feature-unit alone after this child is removed.
+
+Reject:
+- "Misc" / "other" children; that means the split axis was wrong.
+- Children that share requirements: pick one owner per requirement.
+- Children whose absence would break the parent: those are merges or top-level splits, not children.
+
+### 3. For a MERGE: confirm coherence
+
+Ask: *"In one sentence, what does the merged feature do?"* If the user cannot, the merge is wrong. Identify requirements to drop as duplicates, requirements to combine, and the new prefix (typically the dominant feature's prefix).
+
+### 4. Confirm coverage
+
+Before writing, read back every requirement and where it lands. Get explicit confirmation.
+
+## File Layout
+
+After a SPLIT or NEST under a parent:
+
+```
+.trogonai/project/{projectid}/frd/{parent-slug}/
+├── index.frd.md
+├── {child-1-slug}.frd.md
+├── {child-2-slug}.frd.md
+└── ...
+```
+
+If the parent was at `frd/{parent-slug}.frd.md`, read it, write to `frd/{parent-slug}/index.frd.md`, then remove the original file with `rm` only after every child file has been written successfully.
+
+After a SPLIT into top-level peers: each resulting feature is its own `frd/{slug}.frd.md`. The original file is replaced (its requirements have moved out).
+
+After a MERGE: write the merged file at the surviving slug; remove absorbed files with `rm` only after the merged file is successfully written.
+
+## Output: Child FRD
+
+```markdown
+# <Child Feature Name>
+
+- **Project:** {projectid}
+- **Prefix:** {PARENT-PREFIX}-{SUB}
+- **Parent FRD:** ./index.frd.md
+- **Status:** Draft
+- **Last updated:** <YYYY-MM-DD>
+
+## Overview
+
+<1–2 paragraphs scoped to this child: what enhancement it adds, why it matters, the parent it builds on>
+
+## Terminology
+
+- **<Term>:** <definition>
+
+## Requirements
+
+### REQ-{PARENT-PREFIX}-{SUB}-001: <Requirement name>
+**User Story:** As a <role>, I want to <action>, so that I can <outcome>.
+
+**Acceptance Criteria:**
+- AC-{PARENT-PREFIX}-{SUB}-001.1: When <condition>, the system shall <behavior>.
+
+<requirements moved from parent, with IDs renumbered under the new prefix>
+```
+
+When moving requirements from parent to child, renumber under the child's prefix starting at `001`. Preserve the original AC text verbatim: only the IDs change. If the source FRD has extension content, move it only when it is defined by the project's template or convert the relevant behavior into acceptance criteria owned by the resulting feature.
+
+## Output: Parent Umbrella (after a NEST)
+
+Rewrite parent `index.frd.md` so that:
+
+- Overview is unchanged or lightly edited to acknowledge the children.
+- Terminology stays with the parent only if the terms apply project-wide; otherwise move term entries down to the children they belong to.
+- Requirements that remain on the parent are only those that describe the umbrella value (the parent-delivers-value-on-its-own behaviors). Requirements that move to a child are listed at the child instead.
+- A new `## Child FRDs` section enumerates the children with one-line summaries.
+- Extension sections remain only if the project's template defines them and the content still applies to the parent's remaining requirements or parent/child boundaries.
+
+```markdown
+# <Parent Feature Name>
+
+- **Project:** {projectid}
+- **Prefix:** {PARENT-PREFIX}
+- **Parent FRD:** <unchanged>
+- **Status:** Draft
+- **Last updated:** <YYYY-MM-DD>
+
+## Overview
+
+<umbrella narrative; mentions that children exist and what they add>
+
+## Terminology
+
+- <only umbrella-level terms>
+
+## Requirements
+
+<requirements that prove the parent delivers value on its own>
+
+## Child FRDs
+
+- [{child-1-slug}](./{child-1-slug}.frd.md): <summary; parent-delivers-value rule satisfied>
+- [{child-2-slug}](./{child-2-slug}.frd.md): <summary>
+```
+
+## Quality Bar
+
+The restructure is complete when:
+
+- Every original requirement is accounted for: none dropped silently.
+- The parent (after a nest) still passes the feature-unit definition on its own.
+- Every child fails the feature-unit definition without the parent (that is the point).
+- No "misc" or "other" child exists.
+- IDs are renumbered correctly under their owning feature's prefix; no duplicate IDs across the project.
+- Likely downstream Blueprint or Work Order follow-up is identified by human-readable name when the split changes feature boundaries, requirement IDs, or acceptance criteria.
+
+## Anti-Patterns to Reject
+
+- Splitting by implementation layer ("frontend" vs "backend") instead of user-facing capability.
+- Leaving the parent both as an umbrella *and* with its own deep requirements; pick one role per requirement.
+- Calling something a child when removing it would break the parent.
+- Renaming the parent without keeping the original prefix stable when only children are being added (breaks existing IDs).
+
+## Worked Example
+
+**Parent:** User Management: admins can create, view, edit, deactivate users and reset passwords. Delivers value alone.
+
+**Children (correctly nested: parent works without them, they are meaningless without it):**
+
+- User Roles: assign roles for access control
+- User Groups: bulk operations on user sets
+- User Audit Log: change tracking for compliance
+
+If, instead, "Login" had been proposed as a child of User Management, reject it: User Management cannot function without authentication, so Login is not a child.
+
+## Related Skills
+
+- `frd-write`: author a new child or top-level FRD
+- `frd-review`: audit the parent + children after splitting
+- `prd-product-description`: re-check the product-level boundaries after major restructures
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive the operation choice and confirm coverage
+- **Read**: load every target FRD before changing anything
+- **Write**: create new files and rewrite the parent umbrella
+- **Edit**: update Child FRDs lists and surgical sections
+- **Glob**: locate existing FRDs
+- **Grep**: confirm prefix uniqueness and ID collisions
+- **Bash(rm:*)**: remove superseded files only after replacement files are written

--- a/plugins/trogonstack-product-requirements/skills/frd-write/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-write/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: frd-write
+description: Draft a Feature Requirements Document (FRD) using the Overview / Terminology / Requirements template, Product Overview context, source-of-truth checks, and REQ-[PREFIX]-NNN / AC-[PREFIX]-NNN.N acceptance criteria. Supports nested sub-features with appended prefixes. Use when the user wants to spec a feature for engineering to build.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash(rm:*)
+---
+
+# FRD: Write a Feature Requirements Document
+
+## Purpose
+
+Produce a single `.frd.md` file engineers can build from. FRDs follow a consistent three-section structure: **Overview**, **Terminology**, **Requirements**.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before writing when the task touches Product Overview context, existing FRDs, feature hierarchy, ambiguous behavior, or downstream Blueprint / Work Order impact. Use its clarification pattern instead of creating a separate local questioning workflow.
+
+## When to Use
+
+- The user has a feature in mind and needs it specified
+- A Product Overview Document (the `prd-*` files) describes the product shape; a specific feature still needs to be pinned down
+- A vague ticket needs to be turned into something testable
+
+## Resolve Project, Prefix, and Parent
+
+### Project
+
+Determine `projectid`:
+
+1. If supplied, use it verbatim.
+2. Otherwise, ask once. `Glob` `.trogonai/project/*/` to offer existing projects.
+
+### Parent FRD (sub-feature check)
+
+Ask: **is this a top-level feature, or a sub-feature of an existing FRD?**
+
+Apply the sub-feature rule strictly: a child is only a child if **the parent delivers complete value on its own and the child is meaningless without the parent**. If the user describes it as a child but the parent would not work without it, push back; that means it should be merged, not nested.
+
+- **Top-level** → file: `.trogonai/project/{projectid}/frd/{slug}.frd.md`
+- **Child** → `Glob` existing FRDs to pick the parent:
+  - If parent is at `frd/{parent-slug}.frd.md`, promote to `frd/{parent-slug}/index.frd.md` first (read, write to new path, remove the old file with `rm` only after the new index exists).
+  - Write child at `frd/{parent-slug}/{slug}.frd.md`.
+  - Deeper nesting follows the same pattern recursively.
+
+If the target file already exists, read it first and ask **replace** or **refine**.
+
+### Product Context
+
+Before discovery, read the relevant Product Overview files when they exist:
+
+- `personas.prd.md` for user-story roles
+- `product-description.prd.md` for product surfaces and boundaries
+- `business-problem.prd.md` and `current-state.prd.md` for the user pain and status quo
+- `success-metrics.prd.md` for outcome priority
+- `technical-requirements.prd.md` for constraints that acceptance criteria must respect
+
+Also read nearby FRDs that share the same parent, prefix family, or product surface. If the new requirement duplicates an existing requirement, refine the owner instead of creating a second source of truth.
+
+### ID Convention
+
+Requirements and acceptance criteria use stable IDs so they can be referenced unambiguously from code, commits, tickets, tests, and reviews.
+
+- **`REQ-`** stands for **Requirement**: a single cohesive, independently testable capability.
+- **`AC-`** stands for **Acceptance Criterion**: one observable behavior the system must exhibit to satisfy its parent requirement.
+
+Format:
+
+- Requirement id: `REQ-{PREFIX}-NNN` (e.g., `REQ-CHK-003`).
+- Acceptance criterion id: `AC-{PREFIX}-NNN.N`, where `NNN` matches its parent requirement (e.g., `AC-CHK-003.2` is the 2nd acceptance criterion of `REQ-CHK-003`).
+
+### Prefix
+
+Every FRD has a short uppercase prefix used inside its requirement and acceptance ids.
+
+- **Top-level FRDs:** ask the user for a 2–4 letter prefix derived from the feature name (e.g., `CHK` for Checkout, `AUTH` for Auth). Confirm uniqueness by `Grep`-ing existing FRDs in the project for `REQ-<prefix>-`.
+- **Child FRDs:** the prefix is the parent's prefix + `-` + a 2–3 letter sub-prefix specific to the child (e.g., parent `AUTH` + child Password Reset → `AUTH-PR`). The full requirement id then looks like `REQ-AUTH-PR-001`.
+
+## Discovery
+
+### 1. Overview
+
+Drive the user to produce **1–2 narrative paragraphs** answering:
+
+- What the feature does
+- Why users need it (problem solved, value delivered)
+- How it relates to the rest of the product (integrations, dependencies, but not implementation)
+
+A stakeholder should understand the purpose in under a minute. Reject paragraphs that describe mechanisms or implementation: the Overview is purpose, not design.
+
+### 2. Terminology
+
+Ask: *"Which terms specific to this feature could be misunderstood?"*
+
+- Define only feature-specific terms. Do **not** define industry-standard terms (e.g., "API", "user").
+- Each definition is brief and precise.
+- Use the template's term-definition shape: `- **Term:** Definition`.
+- If no ambiguous terms exist, the section may be omitted.
+
+### 3. Requirements
+
+Each requirement represents **one cohesive, independently testable capability**.
+
+For each requirement, drive:
+
+- **Title**: short, capability-shaped (e.g., "Payment Confirmation", not "Show stuff").
+- **User story**: exactly one sentence in the form *"As a [role], I want to [action], so that I can [outcome]."* The role must be a concrete persona. If `personas.prd.md` exists in the project, the role must match (or the deviation must be justified).
+- **Acceptance criteria**: one or more `AC-[PREFIX]-NNN.N` items. Each criterion follows:
+  - **"When [condition], the system shall [behavior]."**: mandatory
+  - **"When [condition], the system should [behavior]."**: recommended
+  - **"When [condition], the system may [behavior]."**: optional
+
+Quality bar for requirements:
+
+- **User-centered**: describes what users need, not internal mechanics.
+- **Testable**: every AC is clear enough to write a test against.
+- **Atomic**: each AC covers exactly one behavior. Split compound ACs.
+- **Coverage**: at least one happy-path AC and at least one failure / edge-case AC per requirement (invalid input, missing permission, conflict, empty state, network failure).
+
+Numbering: requirements are sequential, zero-padded to three digits (`001`, `002`, ...). ACs within a requirement are `NNN.N` (`001.1`, `001.2`, ...).
+
+### 4. Optional Extension Sections
+
+After requirements are stable, decide whether the FRD needs any extension section beyond the guide's three-section shape.
+
+- Add `## Child FRDs` only when this FRD has children.
+- Capture cross-requirement interactions, defaults, constraints, precedence rules, and edge conditions as acceptance criteria whenever possible.
+- Add other extension sections only when the project's Feature Requirements Template provides them.
+- If no extension content is needed, omit the extension section entirely. Do not add a placeholder.
+
+### 5. Split check
+
+If the discovery surfaces more than roughly **5 requirements**, or requirements covering capabilities a different team would own, recommend `frd-split` rather than producing a sprawling FRD.
+
+## Output
+
+Resolve the template source before writing:
+
+1. If the user or project context provides a Project Settings > Requirements > Feature Requirements Template, read and use that template.
+2. Otherwise, use the bundled default at `assets/frd-template.md`.
+
+Write a single file using the resolved template. Substitute the placeholders (feature name, `{projectid}`, `{PREFIX}`, parent path, date), repeat the `REQ-{PREFIX}-NNN` block once per requirement, and fill in each section from the discovery output.
+
+After writing, if a parent FRD exists, append an entry to its `## Child FRDs` section (creating the section if missing):
+
+```markdown
+- [{child-slug}](./{child-slug}.frd.md): <one-line summary>
+```
+
+If refining an existing FRD, call out likely downstream Blueprint or Work Order follow-up when user stories, acceptance criteria, requirement IDs, feature boundaries, or technical constraints changed. Do not edit downstream modules from this skill.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+REQ-CHK-003: Payment Confirmation
+
+User Story: As a customer, I want to receive confirmation after my payment is processed, so that I can know my order was placed successfully.
+
+Acceptance Criteria:
+- AC-CHK-003.1: When payment processing succeeds, the system shall display a confirmation page with the order number and estimated delivery date.
+- AC-CHK-003.2: When payment processing fails, the system shall return the user to the payment form with an error message describing the failure reason.
+- AC-CHK-003.3: When the user navigates away during processing, the system shall complete the transaction and display the confirmation on their next visit.
+```
+
+**Bad** (reject this shape)
+
+```
+REQ-CHK-003: Payment Confirmation
+
+User Story: As a user, I want payment to work.
+
+Acceptance Criteria:
+- AC-CHK-003.1: The system should show a message.
+- AC-CHK-003.2: Errors should be handled appropriately.
+```
+
+The user story has no outcome and uses a generic role. The ACs are untestable: "show a message" and "handled appropriately" do not describe specific behaviors.
+
+## Anti-Patterns to Reject
+
+- "As a user, I want X": generic role; force a concrete persona.
+- ACs without a "When" condition.
+- ACs using "the system handles X appropriately" are not testable.
+- One AC describing multiple behaviors: split.
+- Overview that describes implementation ("uses Stripe webhooks") instead of purpose.
+- Terminology entries for industry-standard terms.
+- Calling something a sub-feature when the parent depends on it; that is a merge, not a nest.
+- Extension sections that prescribe UI, screens, or user flows.
+- Extension sections that restate per-requirement ACs instead of owning new context.
+- Empty extension sections with placeholder text.
+
+## Related Skills
+
+- `frd-split`: break an FRD into independently-valuable parent + nested children
+- `frd-review`: audit an FRD or a tree of FRDs
+- `frd-getting-started`: produce the initial set of FRDs for a new project
+- `prd-personas`: define personas that user stories reference
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery, prefix selection, parent picking
+- **Read**: load parent FRD and personas
+- **Write**: create the FRD file and update parent's Child FRDs list
+- **Glob**: locate existing FRDs and projects
+- **Grep**: check existing requirement prefixes
+- **Bash(rm:*)**: remove the original parent file only after promotion to `index.frd.md` succeeds

--- a/plugins/trogonstack-product-requirements/skills/frd-write/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-write/SKILL.md
@@ -157,7 +157,7 @@ If refining an existing FRD, call out likely downstream Blueprint or Work Order 
 
 **Good**
 
-```
+```markdown
 REQ-CHK-003: Payment Confirmation
 
 User Story: As a customer, I want to receive confirmation after my payment is processed, so that I can know my order was placed successfully.
@@ -170,7 +170,7 @@ Acceptance Criteria:
 
 **Bad** (reject this shape)
 
-```
+```markdown
 REQ-CHK-003: Payment Confirmation
 
 User Story: As a user, I want payment to work.

--- a/plugins/trogonstack-product-requirements/skills/frd-write/assets/frd-template.md
+++ b/plugins/trogonstack-product-requirements/skills/frd-write/assets/frd-template.md
@@ -1,0 +1,37 @@
+# <Feature Name>
+
+- **Project:** {projectid}
+- **Prefix:** {PREFIX}
+- **Parent FRD:** <relative path or "none (top-level)">
+- **Status:** Draft
+- **Last updated:** <YYYY-MM-DD>
+
+## Overview
+
+Provide a clear and concise summary of the feature, explaining what it does and the value it delivers to the user. Describe the core problem this feature solves and how it fits into the overall product.
+
+## Terminology
+
+- **Key Term 1:** Brief description that ensures shared understanding across the team.
+- **Key Term 2:** Definition that clarifies any ambiguity in how this concept is used.
+
+## Requirements
+
+### REQ-{PREFIX}-001: Requirement Name
+
+**User Story:** As a [role], I want to [perform action], so that I can [achieve outcome].
+
+**Acceptance Criteria:**
+
+- AC-{PREFIX}-001.1: When the user [performs action], the system shall [respond with specific, observable behavior].
+- AC-{PREFIX}-001.2: When [failure / edge condition occurs], the system shall [observable behavior, e.g., return error code, display named message, persist record].
+- AC-{PREFIX}-001.N: [Continue for all acceptance criteria: each atomic, each testable]
+
+### REQ-{PREFIX}-002: Requirement Name
+
+**User Story:** As a [role], I want to [perform action], so that I can [achieve outcome].
+
+**Acceptance Criteria:**
+
+- AC-{PREFIX}-002.1: When [condition], the system shall [behavior].
+- AC-{PREFIX}-002.2: [Continue for all acceptance criteria]

--- a/plugins/trogonstack-product-requirements/skills/prd-business-problem/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-business-problem/SKILL.md
@@ -90,7 +90,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/business-problem.p
 
 **Good**
 
-```
+```markdown
 ## The Problem
 Mid-market sales reps at companies of 200–2000 employees who manage 30–80 active
 deals at once in Salesforce spend 45–60 minutes per day re-entering deal notes
@@ -119,7 +119,7 @@ forecast accuracy to keep declining into Q4 board reviews and to lose another
 
 **Bad**
 
-```
+```markdown
 ## The Problem
 Our users find the current experience frustrating and want something better.
 

--- a/plugins/trogonstack-product-requirements/skills/prd-business-problem/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-business-problem/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: prd-business-problem
+description: Draft the Business Problem of a PRD by framing the core problem the product addresses, the gaps in today's tools and processes, and why change is necessary now. Drives discovery through who experiences the pain, what fails today, and the cost of inaction. Writes to `.trogonai/project/{projectid}/prd/business-problem.prd.md`. Use when the user wants to write, refine, or audit the problem framing of a product or feature.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD: Business Problem
+
+## Purpose
+
+Produce the **Business Problem** file of a PRD: the core problem the product addresses, what current tools and processes fail to solve, and why change is necessary now: grounded in evidence.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` when the problem framing depends on existing product context, artifacts, unclear source of truth, or clarification before editing.
+
+## When to Use
+
+- The user is starting a PRD and needs to frame the problem
+- An existing PRD has a vague problem statement that needs sharpening
+- The user is pitching an idea and needs to validate there is a real problem before designing a solution
+
+## Project Identifier
+
+Before writing, determine the `projectid`:
+
+1. If the user has supplied one, use it verbatim.
+2. Otherwise, ask for it once. The `projectid` should be a stable, kebab-case identifier for the product/initiative (e.g., `onboarding-revamp`, `realtime-collab`).
+3. Confirm the resolved path before writing: `.trogonai/project/{projectid}/prd/business-problem.prd.md`.
+
+If the file already exists, read it first and ask whether to **replace** or **refine** before overwriting.
+
+## Discovery
+
+Ask until all three areas are answered concretely. Each section of the template must be backed by evidence (data, tickets, quotes, lost deals, churn signals): opinion alone is not evidence.
+
+1. **The Problem**
+   - Who experiences it? Specific user segment: role, team, persona. Reject "users", "everyone", "our customers".
+   - What pain does it cause, in their words? Symptom and observable behavior, not a missing feature. Reject solution-shaped answers like "we need a dashboard".
+   - Why does it matter? The business or user impact in concrete terms.
+
+2. **Current Gaps**
+   - What tools, processes, or systems do people use today to cope?
+   - Where do those fail: workarounds, manual effort, missing capability, fragmented data, blind spots?
+   - Why are those gaps significant rather than minor inconveniences?
+
+3. **Why Change Is Necessary**
+   - What is the trigger making this urgent now: a market shift, a deadline, an escalation, a strategic bet?
+   - What happens if nothing changes in the next quarter / year?
+   - What opportunity is at risk: revenue, retention, competitive position, regulatory standing?
+
+If the user describes a solution, ask: *"What pain does that solve, for whom, and how do you know they have it?"* Restart from step 1.
+
+If the user describes a metric improvement ("increase conversion"), ask: *"What is the user-facing symptom that drives that metric today?"*
+
+## Quality Bar
+
+The file is complete when:
+
+- A reader unfamiliar with the project can name the affected user segment and the pain they feel
+- Current Gaps name real tools, processes, or systems, not abstractions like "the current experience"
+- Why Change Is Necessary points to a concrete trigger and a named consequence of inaction
+- At least one concrete piece of evidence (a number, a quote, a ticket count, a lost deal) is woven into the document, not just "we hear this a lot"
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/business-problem.prd.md` using the template at `assets/business-problem-template.md`. Read it, substitute `{projectid}` and the date, and fill in each section from the discovery output.
+
+## Writing Guidance
+
+### Writing approach
+- **Complete paragraphs, not bullet grids.** Each section is prose that tells a story and supplies context. Lists belong inside paragraphs only when they enumerate concrete evidence.
+- **Defend every claim.** A problem statement, a gap, or a "why now" is only acceptable when paired with the reasoning or evidence that supports it. If a sentence could be deleted without losing the argument, delete it.
+- **Lead with the why before the what.** The reader is a stakeholder deciding whether this is worth doing. Anchor on motivation; mechanics belong in `prd-product-description`.
+- **Weave evidence into the prose.** Numbers, quotes, and named incidents belong inside the paragraphs, not in a separate evidence list.
+
+### Tone and language
+- **Active voice and concrete nouns.** Name the actor, the action, and the object. "Reps re-enter notes" beats "notes are re-entered."
+- **No fluffy adjectives.** Forbidden words include *comprehensive, sophisticated, seamless, powerful, engaging, robust, world-class, cutting-edge, next-generation*. If the sentence relies on one of these, rewrite it with a measurable fact.
+- **Readable by both technical and non-technical stakeholders.** No internal acronyms, no jargon without a definition the first time it appears.
+
+### Scope
+- **Problem, not solution.** Anything that prescribes how to build, what the UI looks like, or which technology to use is out of scope here. Park solution ideas for `prd-product-description`.
+- **No invention.** Every claim must come from the user's input or named project context (interviews, tickets, dashboards, contracts). If a fact is not available, ask for it rather than fabricating one.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+## The Problem
+Mid-market sales reps at companies of 200–2000 employees who manage 30–80 active
+deals at once in Salesforce spend 45–60 minutes per day re-entering deal notes
+from Zoom calls. They miss follow-ups because notes live in three places
+(Zoom chat, their notebook, Salesforce), and managers cannot see deal status
+without DMing the rep. This matters because forecast accuracy and rep retention
+both depend on the system of record being current.
+
+## Current Gaps
+Today reps stitch together Zoom's auto-transcripts, a personal notebook, and
+manual Salesforce entry. Salesforce's native call logging requires reps to
+re-listen to recordings; Zoom AI Companion does not write back to Salesforce;
+internal Zapier flows break weekly because Zoom topic strings change. The
+result is that the "next steps" field is blank for 38% of deals at week 2 of
+the cycle, leaving managers without the signal they need to coach or
+intervene.
+
+## Why Change Is Necessary
+Q3 forecast accuracy dropped from 78% to 61% and the CFO escalated to the CRO.
+Two enterprise deals slipped last quarter because follow-ups were missed,
+representing $1.4M in lost ARR. Six of the last nine AE exit interviews cited
+"tooling frustration" as a reason for leaving. If nothing changes, we expect
+forecast accuracy to keep declining into Q4 board reviews and to lose another
+2–3 AEs we cannot afford to backfill before renewal season.
+```
+
+**Bad**
+
+```
+## The Problem
+Our users find the current experience frustrating and want something better.
+
+## Current Gaps
+The existing tools do not work very well and customers have been asking for
+improvements.
+
+## Why Change Is Necessary
+We need to improve the product to stay competitive and keep up with industry
+trends.
+```
+
+The bad version has no segment, no observable pain, no named tools, no
+quantified consequence, and no real evidence: every line could apply to any
+product. A reader is no more motivated after reading it than before.
+
+## Anti-Patterns to Reject
+
+- "Users want a better experience" is not a problem, has no segment, and offers no evidence.
+- "We need feature X": solution stated as problem.
+- "Conversion is low": metric, not a user pain.
+- "Customers have asked for this": push for how many, who specifically, and what they actually said.
+- "Industry trend": push for how it shows up for *this* user segment.
+- "The current tools are bad" in Current Gaps: name the actual tools and the specific failure mode.
+- Fluffy adjectives: "comprehensive", "seamless", "powerful", "engaging" and similar. Replace with a measurable fact.
+- Passive voice that hides the actor: "notes are missed" → who misses them, and how often.
+- Any claim that cannot be traced back to user input or named project context: ask, do not invent.
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`
+- **Read**: load the existing file if it exists, to decide replace vs refine
+- **Write**: write the file

--- a/plugins/trogonstack-product-requirements/skills/prd-business-problem/assets/business-problem-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-business-problem/assets/business-problem-template.md
@@ -1,0 +1,16 @@
+# Business Problem
+
+- **Project:** {projectid}
+- **Last updated:** <YYYY-MM-DD>
+
+## The Problem
+<One or two paragraphs describing the core problem the product addresses.
+Who experiences it? What pain does it cause? Why does it matter now?>
+
+## Current Gaps
+<Explain what is missing today: what tools, processes, or systems fail to
+solve the problem, and why those gaps are significant.>
+
+## Why Change Is Necessary
+<Defend the urgency or strategic importance of solving this problem now.
+What happens if it goes unsolved? What opportunity is at risk?>

--- a/plugins/trogonstack-product-requirements/skills/prd-current-state/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-current-state/SKILL.md
@@ -80,7 +80,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/current-state.prd.
 
 **Good**
 
-```
+```markdown
 ## How the job gets done today
 1. Rep finishes a Zoom call. Notes are in Zoom chat, a physical notebook, or both.
 2. Rep opens Salesforce, finds the right opportunity, copy-pastes notes into the Activity log.
@@ -101,7 +101,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/current-state.prd.
 
 **Bad**
 
-```
+```markdown
 ## How the job gets done today
 1. Users use Salesforce.
 2. They enter their notes.

--- a/plugins/trogonstack-product-requirements/skills/prd-current-state/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-current-state/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: prd-current-state
+description: Draft the Current State of a PRD by documenting the status quo the product improves upon. Drives discovery through what users do today, the workarounds in use, the costs of the status quo, and the alternatives that already exist. Writes to `.trogonai/project/{projectid}/prd/current-state.prd.md`. Use when the user wants to document the baseline before proposing a change.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD: Current State
+
+## Purpose
+
+Describe the status quo the product is intended to improve upon, so the value of the change is measurable and the "do nothing" baseline is explicit.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` when the current-state baseline depends on existing product context, artifacts, unclear source of truth, or clarification before editing.
+
+## When to Use
+
+- A new PRD needs its baseline documented
+- An existing PRD jumps to the solution without describing what exists today
+- The user wants to justify investment by quantifying the cost of the current state
+
+## Project Identifier
+
+Before writing, determine the `projectid`:
+
+1. If the user has supplied one, use it verbatim.
+2. Otherwise, ask for it once. The `projectid` should be a stable, kebab-case identifier for the product/initiative.
+3. Confirm the resolved path before writing: `.trogonai/project/{projectid}/prd/current-state.prd.md`.
+
+If the file already exists, read it first and ask whether to **replace** or **refine** before overwriting.
+
+## Discovery
+
+Ask until all are answered:
+
+1. **What do affected users do today** to get the job done? Walk through the actual steps, tools, and handoffs.
+2. **What workarounds are in use?** Spreadsheets, manual processes, copy-paste, side scripts, hiring more humans. Workarounds are the strongest evidence of unmet need.
+3. **What alternatives already exist**: internal tools, competitor products, third-party services? Why are they not used, or why are they insufficient?
+4. **What does the current state cost?** Time per task, error rate, support load, lost revenue, abandonment, hours of toil. Quantify where possible.
+5. **What is intentionally left alone?** Parts of the current state that are acceptable and not in scope to change.
+
+Push back on "there is no current process": there is always a current state, even if it is "users do not do this at all and the business loses the opportunity".
+
+## Quality Bar
+
+The file is complete when:
+
+- The current workflow can be reconstructed by a reader who has never used the product
+- At least one quantified cost is present (time, money, error rate, volume)
+- Workarounds are named, not implied
+- The relationship to existing alternatives (internal or external) is explicit
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/current-state.prd.md` using the template at `assets/current-state-template.md`. Read it, substitute `{projectid}` and the date, and fill in each section from the discovery output.
+
+## Writing Guidance
+
+### Writing approach
+- **Reconstruct the workflow concretely.** Walk a reader through the actual steps users take today, in the order they take them, with the tools they touch. Skipping a step hides the friction it causes.
+- **Name workarounds and tools by name.** "A spreadsheet" is invisible; "a shared Google Sheet titled `Pipeline Reconciliation v7`" is evidence. Workarounds are the strongest signal of unmet need: give them the page space they deserve.
+- **Quantify the cost.** Every cost in the table needs a number with a unit and a source. "A lot" is not a cost.
+- **Treat alternatives honestly.** Internal tools, competitors, third-party services: say what they do and *why they fall short for this user*, not why they are bad in general.
+
+### Tone and language
+- **Plain language.** Anyone in the company should be able to read this and understand what users do today, without internal jargon.
+- **Specific, not impressionistic.** "Slow" is impressionistic; "45 minutes per deal" is specific. The reader should feel the friction.
+- **Cost, not complaint.** Translate complaints into observable cost: time, errors, lost revenue, headcount, abandonment.
+
+### Scope
+- **Today, not tomorrow.** Resist sliding into the desired state. Future workflow belongs in `prd-product-description`.
+- **Baseline, not solution.** Even when a workaround obviously points to a feature, this file documents the workaround: feature proposals live in `prd-product-description` and FRDs.
+- **No invention.** Every step, workaround, and cost must come from observed behavior, interviews, dashboards, or tickets. If the source is unknown, ask rather than guess.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+## How the job gets done today
+1. Rep finishes a Zoom call. Notes are in Zoom chat, a physical notebook, or both.
+2. Rep opens Salesforce, finds the right opportunity, copy-pastes notes into the Activity log.
+3. Rep manually edits the "Next Steps" field. ~40% of the time this field is skipped because the rep is on their next call.
+4. Manager pulls the deal report Monday morning; for deals with blank fields, manager DMs the rep individually.
+
+## Workarounds in use
+- Personal Notion / Apple Notes pages: 7 of 12 reps maintain a parallel deal tracker because Salesforce notes are not searchable from mobile.
+- Weekly "pipeline review" meeting (60 min, 14 attendees) exists primarily to reconcile what Salesforce says vs what reps actually know.
+
+## Cost of the status quo
+| Cost | Measure | Source |
+|------|---------|--------|
+| Rep time on Salesforce data entry | 45–60 min/day per rep × 22 reps | Time-tracking survey, Mar 2026 |
+| Forecast accuracy | 61% (down from 78% YoY) | Salesforce forecast vs actual close |
+| Manager toil chasing notes | ~6 hours/week per sales manager | Manager interviews, 4/5 |
+```
+
+**Bad**
+
+```
+## How the job gets done today
+1. Users use Salesforce.
+2. They enter their notes.
+
+## Workarounds in use
+- People do things outside the system sometimes.
+
+## Cost of the status quo
+| Cost | Measure | Source |
+|------|---------|--------|
+| Time | A lot | Anecdote |
+```
+
+The bad version is unfalsifiable: no reader can act on it. The good version names actors, counts steps, and quantifies cost with a source.
+
+## Anti-Patterns to Reject
+
+- "Nothing exists today": there is always a status quo, including doing nothing.
+- "It's slow": push for a number.
+- "Users complain": push for what they do instead, and the cost of doing it.
+- Describing the future state in this file; that belongs in `prd-product-description`.
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`
+- **Read**: load the existing file if it exists, to decide replace vs refine
+- **Write**: write the file

--- a/plugins/trogonstack-product-requirements/skills/prd-current-state/assets/current-state-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-current-state/assets/current-state-template.md
@@ -15,6 +15,7 @@
 - <tool / product / process>: <why it falls short>
 
 ## Cost of the status quo
+
 | Cost | Measure | Source |
 |------|---------|--------|
 | <time / errors / revenue / toil> | <number with unit> | <how known> |

--- a/plugins/trogonstack-product-requirements/skills/prd-current-state/assets/current-state-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-current-state/assets/current-state-template.md
@@ -1,0 +1,23 @@
+# Current State
+
+- **Project:** {projectid}
+- **Last updated:** <YYYY-MM-DD>
+
+## How the job gets done today
+1. <step>
+2. <step>
+3. <step>
+
+## Workarounds in use
+- <workaround>: <who uses it, how often>
+
+## Existing alternatives
+- <tool / product / process>: <why it falls short>
+
+## Cost of the status quo
+| Cost | Measure | Source |
+|------|---------|--------|
+| <time / errors / revenue / toil> | <number with unit> | <how known> |
+
+## Left alone (out of scope to change)
+- <part of current state that stays>

--- a/plugins/trogonstack-product-requirements/skills/prd-custom-overview/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-custom-overview/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: prd-custom-overview
+description: Draft an additional Product Overview Document beyond the six defaults when a product-specific context area is needed. Keeps custom PRDs at product-level why/what, prevents duplicate default sections, and writes to `.trogonai/project/{projectid}/prd/{slug}.prd.md`. Use when the user needs a custom overview document rather than a feature requirement.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Glob
+  - Grep
+---
+
+# PRD: Custom Product Overview Document
+
+## Purpose
+
+Create an additional Product Overview Document when the six defaults do not capture a product-specific context area the team needs before feature work.
+
+Custom overview documents are still product-level documents. They explain **why** a context area matters or **what** the product is at a broad level. They do not define feature acceptance criteria, engineering design, or implementation plans.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before creating a custom overview. Use its source-of-truth and clarification rules to decide whether the new document should exist, which default document it overlaps with, and what it must not own.
+
+## When to Use
+
+- The six default Product Overview Documents are present, but the product has another context area reviewers need to understand
+- A stakeholder asks for a product-level overview that does not fit Business Problem, Current State, Personas, Product Description, Success Metrics, or Technical Requirements
+- The team needs to document product-wide assumptions, market context, rollout strategy, domain model, glossary, or operating constraints before writing FRDs
+
+## Resolve Project and Document
+
+1. Determine `projectid`:
+   - If supplied, use it verbatim.
+   - Otherwise, ask once. `Glob` `.trogonai/project/*/` to offer existing projects.
+2. Ask for a short document title and derive a kebab-case `{slug}`.
+3. `Glob` `.trogonai/project/{projectid}/prd/*.prd.md` and reject slugs that collide with reserved files or existing custom documents.
+4. `Grep` existing PRD files for the same title or purpose. If a default document already covers the need, recommend that skill instead of creating a duplicate.
+
+Reserved files that should not be recreated as custom documents:
+
+- `business-problem.prd.md`
+- `current-state.prd.md`
+- `personas.prd.md`
+- `product-description.prd.md`
+- `review.prd.md`
+- `success-metrics.prd.md`
+- `technical-requirements.prd.md`
+
+## Discovery
+
+Ask until each area is concrete:
+
+1. **Purpose**: what question should this document answer for an executive, product manager, or engineer before they read FRDs?
+2. **Type**: is this primarily **why** context, **what** context, or a blend? If it is feature behavior, redirect to `frd-write`.
+3. **Audience**: who needs this document, and what decision will it help them make?
+4. **Scope**: what is included, and what adjacent topic is intentionally excluded?
+5. **Source of truth**: what inputs support the document: user research, market data, legal policy, sales notes, architecture constraints, operations runbooks, or stakeholder decisions?
+6. **Relationship to defaults**: which default PRD files should this document reference, and which should remain the owner for overlapping material?
+7. **Relationship to custom overviews**: does this extend an existing custom overview, sit beside it, or stand alone? Name the parent or sibling relationship in the document instead of creating an unowned flat note.
+
+Push back on:
+
+- Custom documents that duplicate a default Product Overview Document
+- Feature-specific acceptance criteria: those belong in FRDs
+- Technical designs, implementation plans, or API contracts: those belong in engineering docs unless they are product-level constraints for `prd-technical-requirements`
+- Vague "miscellaneous" documents with no audience or decision
+
+## Quality Bar
+
+The file is complete when:
+
+- The title and purpose make clear why this needs to exist beyond the six defaults
+- The document is understandable by anyone in the company
+- The scope boundary prevents overlap with default PRD files
+- The parent / sibling relationship is explicit when the document belongs in a larger Product Overview context
+- Every claim has a named source, owner, or open question
+- The document stays at product-level why/what and does not drift into FRD acceptance criteria
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/{slug}.prd.md` using the template at `assets/custom-overview-template.md`. Read it, substitute `{projectid}`, `{title}`, `{slug}`, and the date, then fill in each section from discovery.
+
+## Writing Guidance
+
+### Writing approach
+- **Plain language first.** A custom overview document should be readable by executives, product managers, designers, and engineers without translation.
+- **Product-level context only.** Explain why the topic matters or what broad product context is true. Do not list feature-level requirements.
+- **Boundary before detail.** Custom documents can become junk drawers unless they name what they are not.
+- **Name the source.** If the document summarizes a decision, policy, research finding, or assumption, cite the source or mark the question open with an owner.
+
+### Tone and language
+- **Concrete nouns and active voice.** Name the actor, decision, constraint, or product concept directly.
+- **No umbrella words.** Avoid "miscellaneous", "general", "etc.", and "various" in titles and headings.
+- **No invention.** If the user cannot identify why the custom document exists, stop and recommend the default PRD skills instead.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+# Rollout Strategy
+
+## Purpose
+This document explains the product-level rollout assumptions for the first three customer cohorts. Sales, Support, and Engineering need the same view of who receives the product first, what success signal allows expansion, and which customer segments are intentionally deferred.
+
+## Scope
+- Included: launch cohort selection, expansion trigger, support readiness, rollback owner.
+- Excluded: feature acceptance criteria, release checklist tasks, infrastructure deployment steps.
+
+## Product Context
+The first cohort is limited to existing mid-market customers with Salesforce and Zoom already connected. This keeps onboarding under the 30-minute support target from `success-metrics.prd.md` and avoids custom integration work during the first validation cycle.
+```
+
+**Bad**
+
+```
+# Misc Notes
+
+This document has everything we did not put elsewhere. It includes rollout,
+analytics, support, APIs, and future UI ideas.
+```
+
+The bad version has no decision, no boundary, and no clear relationship to the default Product Overview Documents.
+
+## Anti-Patterns to Reject
+
+- Creating custom documents before the default six exist, unless the user explicitly says this project does not use the defaults
+- "Miscellaneous" or "General Notes" documents
+- Repeating default sections under a different name
+- Writing feature requirements or acceptance criteria in a custom Product Overview Document
+- Creating a document with no owner, audience, or source of truth
+
+## Related Skills
+
+- `prd-getting-started`: scaffold the six default Product Overview Documents
+- `prd-review`: audit default and custom Product Overview Documents
+- `frd-write`: author feature-level requirements when the topic becomes local behavior
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`, title, slug, and scope
+- **Read**: load existing PRD files and the custom template
+- **Write**: write the custom PRD file
+- **Glob / Grep**: detect project files, slug collisions, and duplicate topics

--- a/plugins/trogonstack-product-requirements/skills/prd-custom-overview/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-custom-overview/SKILL.md
@@ -97,7 +97,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/{slug}.prd.md` usi
 
 **Good**
 
-```
+```markdown
 # Rollout Strategy
 
 ## Purpose
@@ -113,7 +113,7 @@ The first cohort is limited to existing mid-market customers with Salesforce and
 
 **Bad**
 
-```
+```markdown
 # Misc Notes
 
 This document has everything we did not put elsewhere. It includes rollout,

--- a/plugins/trogonstack-product-requirements/skills/prd-custom-overview/assets/custom-overview-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-custom-overview/assets/custom-overview-template.md
@@ -1,0 +1,32 @@
+# {title}
+
+- **Project:** {projectid}
+- **Slug:** {slug}
+- **Type:** Custom Product Overview Document
+- **Parent overview:** <none / default PRD or custom overview this document extends>
+- **Last updated:** <YYYY-MM-DD>
+
+## Purpose
+<What question this document answers, who needs it, and why it belongs outside the six default Product Overview Documents.>
+
+## Scope
+- **Included:** <product-level context this document owns>
+- **Excluded:** <adjacent context owned by default PRDs, FRDs, or engineering design docs>
+
+## Product Context
+<Plain-language why/what context. Keep this at product level; do not define feature acceptance criteria.>
+
+## Relationship to Default PRDs
+- **Business Problem:** <related / not related; how overlap is avoided>
+- **Current State:** <related / not related; how overlap is avoided>
+- **Personas:** <related / not related; how overlap is avoided>
+- **Product Description:** <related / not related; how overlap is avoided>
+- **Success Metrics:** <related / not related; how overlap is avoided>
+- **Technical Requirements:** <related / not related; how overlap is avoided>
+
+## Relationship to Custom Overviews
+- **Parent / sibling context:** <none / document name; why this belongs here>
+
+## Sources and Open Questions
+- **Source:** <research, dashboard, stakeholder decision, policy, or artifact>
+- **Open question:** <question>; owner: <name>, needed by: <date>

--- a/plugins/trogonstack-product-requirements/skills/prd-getting-started/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-getting-started/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: prd-getting-started
+description: Initialize a new project with the six default Product Overview Documents (business problem, current state, personas, product description, success metrics, technical requirements). Scaffolds stubs and walks the user through running each section skill in priority order. Use when the user is starting a project and there are no PRD files yet.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Glob
+---
+
+# PRD Getting Started: Initial Product Overview Set
+
+## Purpose
+
+Every project starts with the same six Product Overview Documents. This skill creates them once, in priority order, so the user has a complete baseline they can fill in section by section.
+
+This is the PRD counterpart to `frd-getting-started`.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` when the task involves clarification, existing product context, custom overview ownership, feature handoff, or downstream Blueprint / Work Order impact. Use its clarification pattern instead of creating a separate local questioning workflow.
+
+## When to Use
+
+- A project has just been created and `.trogonai/project/{projectid}/prd/` is empty
+- The user wants the full Product Overview baseline before starting any feature work
+- The user just produced a rough product idea and wants to translate it into a structured overview
+
+## Resolve Project
+
+1. Determine `projectid` (ask if not supplied; offer choices via `Glob` of `.trogonai/project/*/`).
+2. `Glob` `.trogonai/project/{projectid}/prd/*.prd.md`: if any default files already exist, ask whether to **skip existing and only scaffold what's missing**, or **stop** (this skill is for getting started, not for re-initialization). Suggest the individual `prd-*` skills for refining existing files.
+
+## Pick the Working Style
+
+Ask the user which style fits this project:
+
+- **Quick scaffold**: write stubs for all six files immediately, then hand off to the individual `prd-*` skills for the user to fill in at their own pace. Best when the user wants to see the shape first and fill in over time.
+- **Guided pass**: walk through the six skills in priority order in this session, running each one back-to-back. Best when the user wants a complete first draft today.
+
+If unclear, default to **Quick scaffold**: it is reversible.
+
+## Priority Order
+
+The six default PODs in recommended discovery order (later docs reference earlier ones):
+
+1. `prd-business-problem`: why this exists at all
+2. `prd-current-state`: what is being improved
+3. `prd-personas`: who it serves (referenced by every later doc)
+4. `prd-product-description`: what the product is
+5. `prd-success-metrics`: how success is measured (references personas)
+6. `prd-technical-requirements`: what the build must satisfy
+
+## Scaffold the Stubs
+
+For each of the six PODs that does not already exist, write a stub file at `.trogonai/project/{projectid}/prd/{filename}` with the headings present but the bodies marked for completion.
+
+### Stub template for each file
+
+```markdown
+# <Section Title>
+
+- **Project:** {projectid}
+- **Status:** Stub
+- **Last updated:** <YYYY-MM-DD>
+
+> This is a stub. Run the corresponding skill (`<skill-name>`) to author the full content.
+
+<headings from the section's template, each with a placeholder body>
+```
+
+Use the exact section template defined by the matching `prd-*` skill (don't invent new headings). Stubs preserve the headings so later edits don't have to recreate them.
+
+| File | Skill | Section Title |
+|------|-------|---------------|
+| `business-problem.prd.md` | `prd-business-problem` | Business Problem |
+| `current-state.prd.md` | `prd-current-state` | Current State |
+| `personas.prd.md` | `prd-personas` | Personas |
+| `product-description.prd.md` | `prd-product-description` | Product Description |
+| `success-metrics.prd.md` | `prd-success-metrics` | Success Metrics |
+| `technical-requirements.prd.md` | `prd-technical-requirements` | Technical Requirements |
+
+## Hand-off
+
+After scaffolding, write `.trogonai/project/{projectid}/prd/_getting-started.md`:
+
+```markdown
+# Getting Started: Initial Product Overview Set
+
+- **Project:** {projectid}
+- **Date:** <YYYY-MM-DD>
+- **Style:** <Quick scaffold / Guided pass>
+
+## Scaffolded
+- [business-problem.prd.md](./business-problem.prd.md): author with `prd-business-problem`
+- [current-state.prd.md](./current-state.prd.md): author with `prd-current-state`
+- [personas.prd.md](./personas.prd.md): author with `prd-personas`
+- [product-description.prd.md](./product-description.prd.md): author with `prd-product-description`
+- [success-metrics.prd.md](./success-metrics.prd.md): author with `prd-success-metrics`
+- [technical-requirements.prd.md](./technical-requirements.prd.md): author with `prd-technical-requirements`
+
+## Next Steps
+1. Run the six skills in priority order. Personas (3) should be authored before Success Metrics (5).
+2. Run `prd-review` once a meaningful chunk is authored.
+3. Move on to `frd-getting-started` to scaffold the initial Feature Requirements set.
+4. Use `prd-custom-overview` only if the project needs a product-level context document beyond the six defaults.
+```
+
+If the user picked **Guided pass**, after writing the summary, recommend running `prd-business-problem` next and stop. The user (or the agent on the next turn) can invoke each subsequent skill.
+
+## Quality Bar
+
+The initialization is complete when:
+
+- All six stub files exist (or were intentionally skipped because they already existed).
+- The hand-off summary names the matching skill for each file.
+- The user knows the priority order and what to do next.
+
+## Anti-Patterns to Reject
+
+- Trying to fully author every POD in this skill; that bypasses per-section discovery, and each `prd-*` skill is responsible for its own quality bar.
+- Re-running against a project that already has all six files; use the individual `prd-*` skills instead.
+- Inventing additional sections inside the six defaults; use `prd-custom-overview` when the product needs a separate custom Product Overview Document.
+
+## Related Skills
+
+- `prd-business-problem`, `prd-current-state`, `prd-personas`, `prd-product-description`, `prd-success-metrics`, `prd-technical-requirements`: author each section
+- `prd-review`: audit once authoring is meaningful
+- `prd-custom-overview`: author additional Product Overview Documents beyond the six defaults
+- `frd-getting-started`: translate the overview into the initial Feature Requirements set
+
+## Allowed Tools
+
+- **AskUserQuestion**: resolve `projectid` and the working style
+- **Read**: load existing files if partial state was detected
+- **Write**: scaffold the six stubs and the hand-off summary
+- **Glob**: detect existing files and list candidate projects

--- a/plugins/trogonstack-product-requirements/skills/prd-personas/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-personas/SKILL.md
@@ -87,7 +87,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/personas.prd.md` u
 
 **Good**
 
-```
+```markdown
 ## Primary: Mid-market Account Executive
 - **Context:** Works from a laptop between back-to-back Zoom calls; 30–80 active opportunities; reports to a Sales Manager who runs weekly pipeline review.
 - **Job to be done:** "End the day knowing every deal moved forward, without spending the evening typing notes."
@@ -110,7 +110,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/personas.prd.md` u
 
 **Bad**
 
-```
+```markdown
 ## Primary: Sales user
 - **Context:** Uses our product.
 - **Job to be done:** Sell more.

--- a/plugins/trogonstack-product-requirements/skills/prd-personas/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-personas/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: prd-personas
+description: Draft the Personas of a PRD by defining the users, their goals, and what success looks like for them. Drives discovery through who the users are, the jobs they are trying to do, their constraints, and the per-persona definition of success. Writes to `.trogonai/project/{projectid}/prd/personas.prd.md`. Use when the user wants to define or sharpen who the product is for.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD: Personas
+
+## Purpose
+
+Define the users the product serves, the jobs they are trying to get done, and what success looks like *for them*, not for the business. Personas grounded in real roles make scope and tradeoffs much easier to decide later.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` when persona decisions depend on existing product context, artifacts, unclear source of truth, or clarification before editing.
+
+## When to Use
+
+- A PRD targets "users" or "everyone" and needs sharpening
+- The team is unclear which user types are primary vs incidental
+- Design or scope decisions are stuck because the audience is fuzzy
+
+## Project Identifier
+
+Before writing, determine the `projectid`:
+
+1. If the user has supplied one, use it verbatim.
+2. Otherwise, ask for it once. The `projectid` should be a stable, kebab-case identifier for the product/initiative.
+3. Confirm the resolved path before writing: `.trogonai/project/{projectid}/prd/personas.prd.md`.
+
+If the file already exists, read it first and ask whether to **replace** or **refine** before overwriting.
+
+## Discovery
+
+For each candidate persona, ask until all are answered:
+
+1. **Identity**: role / job title / team / context. Concrete enough that the user could name a real person who fits.
+2. **Job to be done**: what outcome are they trying to achieve, in their own framing? Not the feature they want; the result they need.
+3. **Constraints**: time, expertise, tools they already use, permissions, environment (mobile / desktop / shop floor / on-call).
+4. **Frequency / intensity**: daily power user, occasional, one-time. This shapes onboarding and depth.
+5. **Definition of success for them**: what does a good outcome feel like from their seat? Saved time, fewer escalations, confidence, control.
+6. **Priority**: primary, secondary, or explicitly out of scope.
+
+Then ask: **who is explicitly NOT a persona for this product?** Excluding someone is as informative as including them.
+
+Push back on:
+
+- A single "user" persona: there are usually 2–3 distinct ones (e.g., end user, admin, support)
+- Personas defined by demographics ("millennials") rather than role / job
+- Personas that mirror internal org charts rather than user reality
+
+## Quality Bar
+
+The file is complete when:
+
+- Each persona has a role, a job to be done, and their own definition of success
+- Primary vs secondary is explicit
+- At least one excluded persona is named
+- Each persona is distinguishable from the others by behavior or context, not just label
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/personas.prd.md` using the template at `assets/personas-template.md`. Read it, substitute `{projectid}` and the date, repeat the persona block once per persona (marking primary vs secondary), and fill in each section from the discovery output.
+
+## Writing Guidance
+
+### Writing approach
+- **Make the user feel real.** A reader should picture a specific person at a specific moment, not a category. Anchor each persona in their role, environment, and a representative day.
+- **One block per persona, in prose.** Identity, job to be done, constraints, frequency, and success live together so the reader meets a person, not a spreadsheet row.
+- **Success from their seat.** What does a good day look like for *them*? Saved time, fewer escalations, looking competent to a peer. Business outcomes belong in `prd-success-metrics`.
+- **Exclude on purpose.** Naming who is *not* the persona is one of the highest-leverage decisions in a PRD: it prevents months of accidental scope. Treat the exclusions list as load-bearing.
+
+### Tone and language
+- **Plain language.** No internal acronyms, no segmentation jargon. Anyone in the company should recognize the persona.
+- **Role and job, not demographic.** "Mid-market AE managing 30–80 deals" beats "millennials" or "power user". Persona is what they do and need, not who they are demographically.
+- **Use their voice when you have it.** A real quote from a user interview is worth more than a paraphrase. If you have one, weave it in.
+
+### Scope
+- **Who, not what.** Behaviors, constraints, and definitions of success, not the features they want. Feature opinions belong in FRDs.
+- **Primary vs secondary is explicit.** Without that, every persona will be treated as equally important and tradeoffs become unresolvable.
+- **No invention.** Every persona comes from real users, sales conversations, or named research. If a persona is hypothetical, mark it as such so reviewers can challenge it.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+## Primary: Mid-market Account Executive
+- **Context:** Works from a laptop between back-to-back Zoom calls; 30–80 active opportunities; reports to a Sales Manager who runs weekly pipeline review.
+- **Job to be done:** "End the day knowing every deal moved forward, without spending the evening typing notes."
+- **Constraints:** Tools already in hand: Zoom, Salesforce, Slack. No tolerance for a new tab. Often on mobile between meetings.
+- **Frequency:** Multiple times per day, every workday.
+- **Success looks like:** Notes captured in under 30 seconds after a call; manager never has to DM them about pipeline state.
+
+## Secondary: Sales Manager (Mid-market)
+- **Context:** Manages 8–15 AEs; spends Monday morning preparing the forecast meeting.
+- **Job to be done:** Trust the pipeline number without manually chasing reps.
+- **Constraints:** Cannot ask reps for more typing; already at burnout risk per last engagement survey.
+- **Frequency:** Daily glance; deep weekly review.
+- **Success looks like:** Forecast accuracy back above 75%; pipeline review meeting cut from 60 min to 20.
+
+## Not a persona (out of scope)
+- Enterprise AEs (deals > $250k ACV): workflow is different (deal desk, legal review); deferred.
+- Sales Operations analysts: they configure but do not live in the deal flow.
+- Customers/buyers: this product is for the seller, not the buyer.
+```
+
+**Bad**
+
+```
+## Primary: Sales user
+- **Context:** Uses our product.
+- **Job to be done:** Sell more.
+- **Constraints:** Wants it to be easy.
+- **Frequency:** Often.
+- **Success looks like:** Increased revenue.
+```
+
+The bad version describes a category, not a person. "Sell more" is the business's goal, not the user's. No reader could rule a feature in or out from it.
+
+## Anti-Patterns to Reject
+
+- "Our users": one undifferentiated blob.
+- "Power users vs casual users": without a behavior that distinguishes them.
+- Demographics-as-persona ("Gen Z customers"): push for the role and job.
+- Success defined only in business terms ("they convert"): must include the user's own definition.
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`
+- **Read**: load the existing file if it exists, to decide replace vs refine
+- **Write**: write the file

--- a/plugins/trogonstack-product-requirements/skills/prd-personas/assets/personas-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-personas/assets/personas-template.md
@@ -1,0 +1,21 @@
+# Personas
+
+- **Project:** {projectid}
+- **Last updated:** <YYYY-MM-DD>
+
+## Primary: <Persona name / role>
+- **Context:** <where, when, with what tools>
+- **Job to be done:** <outcome they need>
+- **Constraints:** <time, expertise, environment>
+- **Frequency:** <daily / weekly / occasional>
+- **Success looks like:** <from their perspective>
+
+## Secondary: <Persona name / role>
+- **Context:** ...
+- **Job to be done:** ...
+- **Constraints:** ...
+- **Frequency:** ...
+- **Success looks like:** ...
+
+## Not a persona (out of scope)
+- <role / segment>: <why excluded>

--- a/plugins/trogonstack-product-requirements/skills/prd-product-description/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-product-description/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: prd-product-description
+description: Draft the Product Description of a PRD by describing what the product is and how its parts fit together. Drives discovery through the one-liner, the user-facing surfaces, the major components, how they interact, and the boundaries of what the product is not. Writes to `.trogonai/project/{projectid}/prd/product-description.prd.md`. Use when the user wants to describe the product shape without diving into requirements.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD: Product Description
+
+## Purpose
+
+Describe what the product is, the surfaces it shows up in, and how its parts fit together: at a level of detail that lets a new engineer, designer, or stakeholder form an accurate mental model in a few minutes.
+
+This file is not the technical design, and it is not the requirements list. It is the **shape** of the product.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before writing when product shape depends on other overview documents, FRD boundaries, unclear source of truth, or downstream Blueprint / Work Order handoff.
+
+## When to Use
+
+- A PRD has goals and personas but no clear picture of what is being built
+- New stakeholders keep asking "wait, what does this actually do?"
+- The team is conflating the technical design with the product description
+
+## Project Identifier
+
+Before writing, determine the `projectid`:
+
+1. If the user has supplied one, use it verbatim.
+2. Otherwise, ask for it once. The `projectid` should be a stable, kebab-case identifier for the product/initiative.
+3. Confirm the resolved path before writing: `.trogonai/project/{projectid}/prd/product-description.prd.md`.
+
+If the file already exists, read it first and ask whether to **replace** or **refine** before overwriting.
+
+## Read Existing Context
+
+Before discovery, read these files when they exist:
+
+- `.trogonai/project/{projectid}/prd/business-problem.prd.md`
+- `.trogonai/project/{projectid}/prd/current-state.prd.md`
+- `.trogonai/project/{projectid}/prd/personas.prd.md`
+
+Use them as the source for why the product exists, what it improves, and who it serves. If the product shape conflicts with those files, ask one clarification question using the shared clarification pattern before writing.
+
+## Discovery
+
+Ask until all are answered:
+
+1. **One-liner**: a single sentence in the form *"<persona> can <do thing> so that <outcome>"*. Refuse multi-clause sentences.
+2. **Surfaces**: where does the user encounter the product? Web app, mobile, CLI, API, email, embedded in another product, physical device.
+3. **Major components**: the named pieces that make up the product (e.g., onboarding flow, ingestion pipeline, dashboard, notification engine). Three to seven is typical; if there are more than ten, group them.
+4. **How the pieces fit together**: a simple flow describing input → processing → output, or the path a user takes through the surfaces. A short ASCII or text diagram is welcome; do not require formal modeling here.
+5. **Primary user flow**: the happy-path scenario for the primary persona in three to seven steps.
+6. **Boundaries (what the product is NOT**) adjacent surfaces, capabilities, or use cases that someone might assume are in but are not. This is the cheapest place to prevent scope creep.
+
+Push back on:
+
+- One-liners that describe the technology ("an event-sourced ingestion service") rather than the value to the user
+- Component lists that read like a microservices inventory rather than user-meaningful parts
+- Skipping the boundaries: boundaries are mandatory
+
+## Quality Bar
+
+The file is complete when:
+
+- The one-liner names a persona, an action, and an outcome
+- A reader can list the major components without re-reading the file
+- The happy-path flow is concrete enough to storyboard
+- At least three "is not" statements are present
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/product-description.prd.md` using the template at `assets/product-description-template.md`. Read it, substitute `{projectid}` and the date, and fill in each section from the discovery output.
+
+## Writing Guidance
+
+### Writing approach
+- **Describe shape, not implementation.** Name the surfaces, components, and flows in product terms. Architecture, data models, and technology choices belong in `prd-technical-requirements` and engineering design docs, not here.
+- **Components in product terms.** A reader should be able to tell what each component *does for the user*, not what microservice it maps to. "Notification engine" beats "kafka-notifications-svc".
+- **Flow as a storyboard.** The primary user flow should read like steps a designer could turn into screens. If the flow needs implementation detail to make sense, it has drifted into design.
+- **Boundaries are mandatory.** The "is NOT" list prevents months of accidental scope. Treat it as load-bearing, not optional.
+
+### Tone and language
+- **Plain language.** No internal acronyms, no platform jargon without a one-line definition.
+- **Name the user encounter.** For every surface and component, say where the user meets it (open the web app, get an email, hit the API).
+- **Avoid "platform for…" framing.** Say what the user *does*, not what the product *is*.
+
+### Scope
+- **What, not how.** Mechanism, schema, and stack live in technical docs.
+- **Shape, not requirements.** Detailed behaviors and acceptance criteria live in FRDs. This file gives the mental model a reader needs before opening any FRD.
+- **No invention.** Every component and surface must come from user input or earlier PRD sections. If something is undecided, mark it as open rather than guessing.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+## One-liner
+A mid-market AE can capture a deal update in under 30 seconds after a Zoom call,
+so Salesforce stays current without evening data entry.
+
+## Surfaces
+- Zoom side-panel app (during and after calls)
+- Salesforce Lightning component (deal record)
+- Mobile web (between meetings)
+
+## Major components
+- **Call Capture:** listens for the end of a Zoom call and proposes a structured note.
+- **Salesforce Bridge:** writes the note to the right opportunity and updates Next Steps.
+- **Coaching Inbox:** surfaces deals where Next Steps is blank, for the manager.
+
+## Primary user flow (happy path)
+1. AE finishes a Zoom call. Side-panel proposes a 3-bullet summary and a Next Step.
+2. AE confirms or edits in <15 seconds.
+3. Salesforce Bridge writes the note and updates Next Steps on the opportunity.
+4. Manager's Coaching Inbox clears the deal from its "blank Next Steps" list.
+
+## What this product is NOT
+- A meeting transcription product: we use Zoom's transcript, we do not produce one.
+- A pipeline analytics tool: managers use existing Salesforce reports.
+- A customer-facing product: buyers never see this; only the selling team does.
+```
+
+**Bad**
+
+```
+## One-liner
+A platform for sales productivity.
+
+## Surfaces
+- Web
+
+## Major components
+- Frontend
+- Backend
+- Database
+
+## Primary user flow (happy path)
+1. User logs in.
+2. User uses the product.
+3. Profit.
+```
+
+The bad version describes infrastructure, not a product. No persona, no outcome, no boundaries: a reader cannot picture what gets built or who uses it.
+
+## Anti-Patterns to Reject
+
+- "A platform for…": say what the user does, not what the product *is*.
+- Listing internal services as components: name user-meaningful parts.
+- "It will support X, Y, Z" without saying *how the user encounters* X, Y, Z.
+- Skipping the "is NOT" boundaries.
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`
+- **Read**: load the existing file if it exists, to decide replace vs refine
+- **Write**: write the file

--- a/plugins/trogonstack-product-requirements/skills/prd-product-description/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-product-description/SKILL.md
@@ -54,7 +54,7 @@ Ask until all are answered:
 3. **Major components**: the named pieces that make up the product (e.g., onboarding flow, ingestion pipeline, dashboard, notification engine). Three to seven is typical; if there are more than ten, group them.
 4. **How the pieces fit together**: a simple flow describing input → processing → output, or the path a user takes through the surfaces. A short ASCII or text diagram is welcome; do not require formal modeling here.
 5. **Primary user flow**: the happy-path scenario for the primary persona in three to seven steps.
-6. **Boundaries (what the product is NOT**) adjacent surfaces, capabilities, or use cases that someone might assume are in but are not. This is the cheapest place to prevent scope creep.
+6. **Boundaries (what the product is NOT)**: adjacent surfaces, capabilities, or use cases that someone might assume are in but are not. This is the cheapest place to prevent scope creep.
 
 Push back on:
 
@@ -97,7 +97,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/product-descriptio
 
 **Good**
 
-```
+```markdown
 ## One-liner
 A mid-market AE can capture a deal update in under 30 seconds after a Zoom call,
 so Salesforce stays current without evening data entry.
@@ -126,7 +126,7 @@ so Salesforce stays current without evening data entry.
 
 **Bad**
 
-```
+```markdown
 ## One-liner
 A platform for sales productivity.
 

--- a/plugins/trogonstack-product-requirements/skills/prd-product-description/assets/product-description-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-product-description/assets/product-description-template.md
@@ -1,0 +1,27 @@
+# Product Description
+
+- **Project:** {projectid}
+- **Last updated:** <YYYY-MM-DD>
+
+## One-liner
+<persona> can <action> so that <outcome>.
+
+## Surfaces
+- <web / mobile / CLI / API / email / embedded / device>
+
+## Major components
+- **<Component name>:** <what it does, in product terms>
+- **<Component name>:** <...>
+
+## How the pieces fit together
+<short prose or text diagram showing the flow between components>
+
+## Primary user flow (happy path)
+1. <step>
+2. <step>
+3. <step>
+
+## What this product is NOT
+- <adjacent thing someone might assume but is excluded>
+- <...>
+- <...>

--- a/plugins/trogonstack-product-requirements/skills/prd-review/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-review/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: prd-review
+description: Review Product Overview Documents for completeness, clarity, source-of-truth conflicts, module-boundary drift, and likely downstream FRD / Blueprint / Work Order impact. Reads the default and custom files under `.trogonai/project/{projectid}/prd/` and writes a review. Use when the user asks to review, audit, critique, or sanity-check a PRD.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Glob
+  - Grep
+---
+
+# Review a Product Requirements Document
+
+## Purpose
+
+Audit a PRD the way an experienced product reviewer would: surface the gaps that cause planning churn, rework, and post-launch surprises.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before reviewing. Use it to check module boundaries, source-of-truth conflicts, clarification needs, and likely downstream Blueprint / Work Order impact.
+
+## When to Use
+
+- Review a PRD draft before sharing it for sign-off
+- Audit an existing PRD against current state
+- Get a second opinion on a spec written by someone else
+- Pre-flight a PRD for an engineering planning session
+
+## Project Identifier
+
+Resolve the `projectid` before reading:
+
+1. If the user supplied one, use it verbatim.
+2. Otherwise, ask once, or `Glob` `.trogonai/project/*/prd/` to list candidates and confirm.
+
+Expected layout:
+
+```
+.trogonai/project/{projectid}/prd/
+├── business-problem.prd.md
+├── current-state.prd.md
+├── personas.prd.md
+├── product-description.prd.md
+├── success-metrics.prd.md
+└── technical-requirements.prd.md
+```
+
+Read whichever files exist. **A missing default file is a finding**, not an error: report it as a Gap in the corresponding section and recommend the matching section skill to author it.
+
+Also read any additional `.prd.md` file in the directory except generated review files. Treat those as custom Product Overview Documents and review them with the custom-document checklist below.
+
+## Review Checklist
+
+Run the PRD against each file. For every item, output one of: **Pass**, **Gap**, **Risk**, **Missing**, **N/A**: with a one-line justification.
+
+### 1. business-problem.prd.md
+- [ ] User segment is concrete (role / team / persona), not "users" or "everyone"
+- [ ] Pain is stated in user terms, not as a solution
+- [ ] "Why now" is answered (trigger, cost of inaction, business impact)
+- [ ] Evidence is concrete (data, tickets, interviews, lost deals), not just opinion
+
+### 2. current-state.prd.md
+- [ ] Today's workflow can be reconstructed from the file
+- [ ] Workarounds in use are named
+- [ ] Existing alternatives (internal or external) are addressed
+- [ ] At least one quantified cost of the status quo (time, errors, revenue, toil)
+- [ ] Parts of current state explicitly left alone are listed
+
+### 3. personas.prd.md
+- [ ] At least one primary persona with role, job to be done, and constraints
+- [ ] Each persona has its own definition of success (not just the business's)
+- [ ] Primary vs secondary is explicit
+- [ ] At least one excluded persona is named
+- [ ] Personas are distinguishable by behavior or context, not just label
+
+### 4. product-description.prd.md
+- [ ] One-liner names a persona, an action, and an outcome
+- [ ] Surfaces (web / mobile / CLI / API / etc.) are listed
+- [ ] Major components are named in product terms, not as an internal service inventory
+- [ ] How the pieces fit together is shown (flow or short diagram)
+- [ ] Primary user happy-path flow is concrete enough to storyboard
+- [ ] At least three explicit "is NOT" boundaries
+
+### 5. success-metrics.prd.md
+- [ ] Exactly one primary outcome metric
+- [ ] Each metric has baseline, target, timeframe, and source
+- [ ] Leading indicators are listed
+- [ ] At least two guardrail metrics with thresholds
+- [ ] Per-persona success metrics present
+- [ ] Instrumentation status is stated; any missing instrumentation has an owner
+- [ ] Decision rules state what result triggers what action
+
+### 6. technical-requirements.prd.md
+- [ ] Performance targets are per user action with percentiles and conditions
+- [ ] Scale targets cover launch and 12 months
+- [ ] Reliability is stated as an SLO with a measurement window
+- [ ] Security covers authn, authz, and data classification
+- [ ] Privacy / compliance regimes are named, not implied
+- [ ] Integration contracts and failure semantics are specified
+- [ ] Platforms, accessibility, and localization are addressed (target or explicit non-constraint)
+- [ ] Observability requirements (logs / metrics / traces / alerts) are listed
+- [ ] Categories that do not apply are marked as explicit non-constraints, not silently skipped
+
+### 7. Cross-file consistency
+- [ ] Personas referenced in `success-metrics.prd.md` exist in `personas.prd.md`
+- [ ] Pain in `business-problem.prd.md` is what `product-description.prd.md` claims to address
+- [ ] Cost of status quo in `current-state.prd.md` is plausibly closed by the primary outcome metric
+- [ ] No "TBD" left unowned in any file
+- [ ] Adjective-only statements ("fast", "scalable", "secure", "better") flagged across files
+
+### 8. Custom Product Overview Documents
+For every non-default `.prd.md` file:
+- [ ] The title and purpose explain why this document exists beyond the six defaults
+- [ ] The scope is product-level why/what, not FRD acceptance criteria or engineering design
+- [ ] The document names which default PRD owns any overlapping material
+- [ ] The document names its parent or sibling relationship when it belongs to a larger custom overview context
+- [ ] Sources, owners, or open questions are named for claims that reviewers may challenge
+- [ ] The document is not a "miscellaneous" bucket
+
+### 9. Operating model and downstream impact
+- [ ] Product-level facts have one clear source of truth
+- [ ] Product Overview content does not drift into FRD acceptance criteria, Blueprint architecture, or Work Order planning
+- [ ] Changes likely to affect FRDs, Blueprints, or Work Orders are called out for downstream follow-up
+- [ ] Open questions are framed with the shared clarification pattern when they block requirements quality
+
+## Output
+
+Write the review to `.trogonai/project/{projectid}/prd/review.prd.md` using this structure:
+
+```markdown
+# PRD Review
+
+- **Project:** {projectid}
+- **Reviewed:** <YYYY-MM-DD>
+- **Overall verdict:** <Ready / Ready with revisions / Not ready>
+
+## Top Findings
+1. <highest-impact gap or risk>
+2. <next>
+3. <next>
+
+## File-by-file Results
+
+### business-problem.prd.md
+- Status: Present / Missing
+- Pass / Gap / Risk: <one line>
+- Fix path: run `prd-business-problem` if changes needed
+
+### current-state.prd.md
+- ...
+
+### personas.prd.md
+- ...
+
+### product-description.prd.md
+- ...
+
+### success-metrics.prd.md
+- ...
+
+### technical-requirements.prd.md
+- ...
+
+### Cross-file consistency
+- ...
+
+### Custom Product Overview Documents
+- ...
+
+### Operating Model and Downstream Impact
+- Source of truth: Pass / Gap / Risk: <one line>
+- Module boundaries: Pass / Gap / Risk: <one line>
+- Likely downstream follow-up: <none / affected FRDs, Blueprints, or Work Orders by human-readable name>
+
+## Required Revisions (blockers)
+- <must fix before sign-off>: fix with `<skill-name>`
+
+## Recommended Revisions (non-blockers)
+- <should fix, not blocking>: fix with `<skill-name>`
+
+## Suggested Questions for the Author
+- <question that exposes an assumption>
+```
+
+If a previous review file exists at the same path, overwrite it.
+
+## Verdict Rubric
+
+- **Ready**: no gaps in `business-problem`, `personas`, `success-metrics`, `technical-requirements`; minor wording only.
+- **Ready with revisions**: gaps exist but the path to fix is clear and small; for each gap, name the section skill (`prd-business-problem`, `prd-current-state`, `prd-personas`, `prd-product-description`, `prd-success-metrics`, `prd-technical-requirements`) to run.
+- **Not ready**: problem framing, success metrics, or personas are missing or solution-shaped. The PRD cannot be planned against as written.
+
+## Key Principles
+
+- **Surface gaps, do not rewrite.** Point to what is missing and why it matters; let the author fix it.
+- **Cite the file.** Every finding references the file it came from.
+- **Distinguish blockers from polish.** Required vs recommended must be obvious.
+- **Be specific.** "Metric is vague" is not feedback; "`success-metrics.prd.md` primary metric 'better onboarding' has no baseline, target, or measurement source" is.
+- **Always recommend the fix path.** Each gap maps to one section skill.
+
+## Related Skills
+
+- `prd-business-problem`, `prd-current-state`, `prd-personas`, `prd-product-description`, `prd-success-metrics`, `prd-technical-requirements`, `prd-custom-overview`
+
+## Allowed Tools
+
+- **AskUserQuestion**: resolve `projectid` if not supplied
+- **Read**: load each PRD file
+- **Glob / Grep**: list projects and locate files
+- **Write**: write the review file

--- a/plugins/trogonstack-product-requirements/skills/prd-review/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-review/SKILL.md
@@ -35,7 +35,7 @@ Resolve the `projectid` before reading:
 
 Expected layout:
 
-```
+```text
 .trogonai/project/{projectid}/prd/
 ├── business-problem.prd.md
 ├── current-state.prd.md

--- a/plugins/trogonstack-product-requirements/skills/prd-success-metrics/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-success-metrics/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: prd-success-metrics
+description: Draft the Success Metrics of a PRD by defining the key metrics used to measure success. Drives discovery through the primary outcome metric, leading indicators, guardrail metrics that must not regress, and the instrumentation source for each. Writes to `.trogonai/project/{projectid}/prd/success-metrics.prd.md`. Use when the user wants to define how success will be measured before building.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD: Success Metrics
+
+## Purpose
+
+Define the metrics that will decide whether the product is working: with baselines, targets, timeframes, and a clear measurement source. A PRD without measurable success criteria cannot be evaluated post-launch.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before writing when metrics depend on personas, business problem, current-state costs, unclear source of truth, or downstream impact.
+
+## When to Use
+
+- A PRD has goals but no numbers to measure against
+- The team is debating whether the product "worked" after launch
+- An existing metrics file is vague ("improve engagement") and needs to be made testable
+
+## Project Identifier
+
+Before writing, determine the `projectid`:
+
+1. If the user has supplied one, use it verbatim.
+2. Otherwise, ask for it once. The `projectid` should be a stable, kebab-case identifier for the product/initiative.
+3. Confirm the resolved path before writing: `.trogonai/project/{projectid}/prd/success-metrics.prd.md`.
+
+If the file already exists, read it first and ask whether to **replace** or **refine** before overwriting.
+
+## Read Existing Context
+
+Before discovery, read these files when they exist:
+
+- `.trogonai/project/{projectid}/prd/business-problem.prd.md`
+- `.trogonai/project/{projectid}/prd/current-state.prd.md`
+- `.trogonai/project/{projectid}/prd/personas.prd.md`
+- `.trogonai/project/{projectid}/prd/product-description.prd.md`
+
+Use them to tie metrics back to the problem, the status quo cost, user success, and the product shape. If the user proposes a metric that does not connect to those sources, ask one clarification question using the shared clarification pattern before writing.
+
+## Discovery
+
+Ask until all are answered:
+
+1. **Primary outcome metric**: the one number that, if it moved, would prove the product solved the business problem. Must include:
+   - Baseline (current value)
+   - Target (desired value)
+   - Timeframe (when measured)
+   - Measurement source (event, query, dashboard, system of record)
+2. **Leading indicators**: earlier signals that predict the primary metric will move. Typically observable within days/weeks, while the primary outcome may take a quarter or more.
+3. **Guardrail / counter-metrics**: what must NOT regress. Latency, conversion elsewhere, support load, cost-to-serve, churn, error rate. Every product change has potential side effects; name the ones the team is unwilling to accept.
+4. **Per-persona success**: for each persona, what is the metric that reflects *their* success (not the business's)? Time-to-value, task completion rate, satisfaction.
+5. **Instrumentation status**: for each metric, can it be measured today, or does instrumentation need to be added? If new, who owns adding it and when?
+6. **Decision rules**: what result triggers what action? E.g., "if primary metric moves <25% by week 8, we revisit scope; if guardrail breaches threshold, we roll back."
+
+Reject:
+
+- "Users will love it" is not measurable
+- "Engagement" without specifying which event
+- "Better performance" without a target number and a timeframe
+- A target with no baseline: without a baseline, you cannot tell whether the target is ambitious or trivial
+
+## Quality Bar
+
+The file is complete when:
+
+- Exactly **one** primary outcome metric is named (multiple primaries means none is primary)
+- Each metric row has baseline, target, timeframe, and source
+- At least two guardrail metrics exist
+- Each metric is measurable from existing or planned instrumentation, and any missing instrumentation has an owner
+- Decision rules state what result triggers what action
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/success-metrics.prd.md` using the template at `assets/success-metrics-template.md`. Read it, substitute `{projectid}` and the date, and fill in each section from the discovery output.
+
+## Writing Guidance
+
+### Writing approach
+- **One number that proves the product worked.** Lead with the primary outcome metric; everything else is supporting. If the file opens with five "primaries", none of them is primary.
+- **Baseline before target.** Without a baseline, "increase X by 20%" is a wish. Every row must show today's value before tomorrow's.
+- **Instrument before you measure.** If a metric depends on instrumentation that does not exist, that is a finding, not a footnote: name the owner and the date.
+- **Decision rules link result to action.** A metric the team will not act on is a vanity metric. Pair each metric with what the team will *do* if it moves or stalls.
+
+### Tone and language
+- **Numeric, not adjectival.** "Activation" is not a metric: "% of new accounts that create their first project in 7 days" is. Replace adjectives with the event or query that produces the value.
+- **Name the source.** Every row references the event, query, dashboard, or system of record that produces it. "Mixpanel funnel `signup → first_project`" beats "product analytics".
+- **Distinguish primary, leading, and guardrail.** They are not interchangeable; the file should make the role of each metric obvious at a glance.
+
+### Scope
+- **Outcome, not output.** "Shipped X features" is an output. The metric measures whether the change in user behavior or business result actually happened.
+- **Business plus per-persona.** Business metrics matter, but each persona should also have a metric that reflects *their* success: otherwise the product can "succeed" while users still suffer.
+- **Exclude vanity metrics.** A metric that can move without the problem being solved is excluded explicitly, not silently.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+## Primary outcome metric
+| Metric | Baseline | Target | Timeframe | Source |
+|--------|----------|--------|-----------|--------|
+| Forecast accuracy (Salesforce forecast vs actual close) | 61% | 78% | Q4 close | Salesforce `Forecast` vs `Opportunity.CloseDate` query |
+
+## Leading indicators
+| Metric | Baseline | Target | Timeframe | Source |
+|--------|----------|--------|-----------|--------|
+| % of deals with non-blank Next Steps at week 2 | 62% | 90% | rolling 4 weeks | Salesforce report `Deal Hygiene v3` |
+| Median seconds from call-end to note saved | 480s | 30s | rolling 2 weeks | Product event `note_saved` − `call_ended` |
+
+## Guardrail metrics (must not regress)
+| Metric | Current | Threshold | Source |
+|--------|---------|-----------|--------|
+| Salesforce write error rate | 0.4% | < 1.0% | Datadog `sfdc.writes.error_rate` |
+| AE weekly Salesforce time | 5.2h | ≤ 5.5h | Time-tracking survey, monthly |
+
+## Per-persona success
+- **Mid-market AE:** median note-save time < 30s (their definition of "stop typing at night").
+- **Sales Manager:** Monday forecast meeting length < 30 min (their definition of "trust the number").
+
+## Decision rules
+- If forecast accuracy moves < 5pp by week 8, we narrow scope to AEs in the West region only.
+- If Salesforce write error rate exceeds 1.0% for 24h, we roll back and pause the rollout.
+```
+
+**Bad**
+
+```
+## Primary outcome metric
+- Engagement
+- Activation
+- Retention
+
+## Leading indicators
+- Users will love it.
+
+## Guardrail metrics
+- Latency should be fine.
+
+## Decision rules
+- We'll check the numbers and decide.
+```
+
+The bad version has three "primaries" (so none is primary), no baselines, no sources, no thresholds, and no rules connecting the numbers to action. Nobody can tell whether the product worked.
+
+## Anti-Patterns to Reject
+
+- Multiple "primary" metrics: pick one.
+- Targets with no baselines.
+- "TBD" instrumentation with no owner.
+- Metrics whose movement does not actually imply the problem is solved (vanity metrics).
+- Guardrails listed but with no threshold: "monitor latency" is not a guardrail.
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`
+- **Read**: load the existing file if it exists, to decide replace vs refine
+- **Write**: write the file

--- a/plugins/trogonstack-product-requirements/skills/prd-success-metrics/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-success-metrics/SKILL.md
@@ -102,7 +102,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/success-metrics.pr
 
 **Good**
 
-```
+```md
 ## Primary outcome metric
 | Metric | Baseline | Target | Timeframe | Source |
 |--------|----------|--------|-----------|--------|
@@ -131,7 +131,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/success-metrics.pr
 
 **Bad**
 
-```
+```md
 ## Primary outcome metric
 - Engagement
 - Activation

--- a/plugins/trogonstack-product-requirements/skills/prd-success-metrics/assets/success-metrics-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-success-metrics/assets/success-metrics-template.md
@@ -4,16 +4,19 @@
 - **Last updated:** <YYYY-MM-DD>
 
 ## Primary outcome metric
+
 | Metric | Baseline | Target | Timeframe | Source |
 |--------|----------|--------|-----------|--------|
 | <metric> | <value> | <value> | <when> | <event / query / dashboard> |
 
 ## Leading indicators
+
 | Metric | Baseline | Target | Timeframe | Source |
 |--------|----------|--------|-----------|--------|
 | <metric> | <value> | <value> | <when> | <source> |
 
 ## Guardrail metrics (must not regress)
+
 | Metric | Current | Threshold | Source |
 |--------|---------|-----------|--------|
 | <metric> | <value> | <max acceptable> | <source> |

--- a/plugins/trogonstack-product-requirements/skills/prd-success-metrics/assets/success-metrics-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-success-metrics/assets/success-metrics-template.md
@@ -1,0 +1,30 @@
+# Success Metrics
+
+- **Project:** {projectid}
+- **Last updated:** <YYYY-MM-DD>
+
+## Primary outcome metric
+| Metric | Baseline | Target | Timeframe | Source |
+|--------|----------|--------|-----------|--------|
+| <metric> | <value> | <value> | <when> | <event / query / dashboard> |
+
+## Leading indicators
+| Metric | Baseline | Target | Timeframe | Source |
+|--------|----------|--------|-----------|--------|
+| <metric> | <value> | <value> | <when> | <source> |
+
+## Guardrail metrics (must not regress)
+| Metric | Current | Threshold | Source |
+|--------|---------|-----------|--------|
+| <metric> | <value> | <max acceptable> | <source> |
+
+## Per-persona success
+- **<Persona>:** <metric reflecting their success, with target>
+
+## Instrumentation status
+- **Ready:** <metrics measurable today>
+- **To build:** <metric>; owner: <name>, needed by: <date>
+
+## Decision rules
+- If <metric> moves <condition> by <date>, then <action>.
+- If <guardrail> breaches <threshold>, then <action>.

--- a/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/SKILL.md
@@ -142,7 +142,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/technical-requirem
 
 **Good**
 
-```
+```md
 ## Performance
 | User action | Metric | Target | Conditions |
 |-------------|--------|--------|------------|
@@ -170,7 +170,7 @@ Write the complete file to `.trogonai/project/{projectid}/prd/technical-requirem
 
 **Bad**
 
-```
+```md
 ## Performance
 - Should be fast.
 

--- a/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: prd-technical-requirements
+description: Draft the Technical Requirements of a PRD by capturing the technical constraints and requirements the product must meet. Drives discovery through performance, scale, reliability, security, privacy, compliance, integrations, platforms, accessibility, and localization. Writes to `.trogonai/project/{projectid}/prd/technical-requirements.prd.md`. Use when the user wants to capture the non-functional and platform constraints engineering will design against.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD: Technical Requirements
+
+## Purpose
+
+Capture the technical constraints and non-functional requirements the product must meet, so engineering can design against concrete targets and the product team can make trade-offs explicit before implementation.
+
+This file is not a technical design or architecture document. It is the contract of constraints the design must satisfy.
+
+## Shared Operating Model
+
+Use `requirements-operating-model` before writing when constraints depend on product shape, metrics, existing context, or Blueprint handoff. Keep architecture decisions in Blueprints.
+
+## When to Use
+
+- A PRD is approaching engineering planning and lacks non-functional targets
+- The team is debating "is this fast enough?" / "is this secure enough?" with no shared bar
+- Compliance, accessibility, or platform constraints are implicit and need to be made explicit
+
+## Project Identifier
+
+Before writing, determine the `projectid`:
+
+1. If the user has supplied one, use it verbatim.
+2. Otherwise, ask for it once. The `projectid` should be a stable, kebab-case identifier for the product/initiative.
+3. Confirm the resolved path before writing: `.trogonai/project/{projectid}/prd/technical-requirements.prd.md`.
+
+If the file already exists, read it first and ask whether to **replace** or **refine** before overwriting.
+
+## Read Existing Context
+
+Before discovery, read these files when they exist:
+
+- `.trogonai/project/{projectid}/prd/product-description.prd.md`
+- `.trogonai/project/{projectid}/prd/success-metrics.prd.md`
+- `.trogonai/project/{projectid}/prd/personas.prd.md`
+
+Use them to ground constraints in user-facing surfaces, measurable goals, and persona contexts. If a technical target becomes an architecture decision, leave the constraint here and identify Blueprints as the owner for the design.
+
+## Discovery
+
+Ask through each category. For every requirement, push for a **number, a threshold, or a named standard**, not adjectives.
+
+1. **Performance**
+   - Target latency (p50, p95, p99) for the primary user actions
+   - Throughput / requests per second or per minute
+   - Cold start, time-to-first-byte, time-to-interactive where relevant
+2. **Scale**
+   - Expected users / tenants / records / events at launch and at 12 months
+   - Peak vs steady-state ratios
+   - Growth assumptions and their source
+3. **Reliability & availability**
+   - SLO (e.g., 99.9% over rolling 30 days)
+   - Acceptable error budget burn
+   - Recovery objectives: RTO, RPO
+   - Graceful degradation expectations
+4. **Security**
+   - Authentication method(s)
+   - Authorization model (roles, scopes, tenancy)
+   - Data classification of inputs and outputs
+   - Threat model concerns specific to this product
+5. **Privacy & compliance**
+   - Regulatory regimes that apply (GDPR, HIPAA, SOC 2, PCI, regional data residency)
+   - PII / PHI / payment data handling
+   - Retention and deletion requirements
+   - Audit logging requirements
+6. **Integrations**
+   - Upstream systems consumed (APIs, events, files)
+   - Downstream systems produced for
+   - Sync vs async, contract ownership, failure semantics
+7. **Platforms & environments**
+   - Supported browsers / OS / device classes
+   - Minimum hardware / network assumptions
+   - Cloud / on-prem / hybrid constraints
+   - Offline / intermittent connectivity behavior
+8. **Accessibility**
+   - WCAG level (typically AA)
+   - Keyboard, screen reader, color contrast, motion expectations
+9. **Localization & internationalization**
+   - Languages at launch and in 12 months
+   - Right-to-left support
+   - Time zone, currency, date/number formatting
+10. **Observability**
+    - Logs, metrics, traces required from day one
+    - Dashboards and alerts that must exist before GA
+11. **Cost constraints**
+    - Unit economics targets (cost per user / request / event) if relevant
+    - Hard ceilings on infrastructure spend
+
+For each category, the acceptable answer is either:
+
+- A concrete requirement with a target, OR
+- An explicit "Not a constraint for this product": which is itself useful information
+
+Push back on:
+
+- "Should be fast" → which action, what percentile, what number, on what hardware/network
+- "Secure by default" → which standard, what threat
+- "Globally available" → which regions, which latency target per region
+
+## Quality Bar
+
+The file is complete when:
+
+- Every category has either a concrete target or an explicit "not a constraint"
+- Performance numbers are tied to specific user actions, not the system as a whole
+- Reliability targets are stated as SLOs with measurement windows
+- Compliance regimes are named, not implied
+- Each requirement is testable: a reviewer could write a verification for it
+
+## Output
+
+Write the complete file to `.trogonai/project/{projectid}/prd/technical-requirements.prd.md` using the template at `assets/technical-requirements-template.md`. Read it, substitute `{projectid}` and the date, and fill in each section from the discovery output. For any category that does not apply, record it under **Explicit non-constraints** rather than dropping the section.
+
+## Writing Guidance
+
+### Writing approach
+- **Number, threshold, or named standard per category.** Every line is either a measurable target, a named regulation/standard, or an explicit non-constraint. Adjectives without numbers do not count.
+- **Per user action, not per system.** "p95 < 200ms" only means something when paired with the action it covers. Latency budgets attach to user actions; SLOs attach to journeys.
+- **Explicit non-constraints are first-class.** A category that does not apply is recorded under non-constraints with the reason. Silence is ambiguous; explicit absence is a decision.
+- **Defend the number.** A target is more useful when paired with how it was chosen (benchmark, contract, regulatory minimum, user research). Numbers without provenance get re-negotiated under pressure.
+
+### Tone and language
+- **No adjectives without numbers.** "Fast", "scalable", "secure", "globally available" are flags to push back on. Replace with a value, a percentile, and a condition.
+- **Name the standard.** WCAG AA, SOC 2 Type II, PCI DSS v4, GDPR Art. 17: name the regime and the article/level when relevant. "Follows best practices" is not a requirement.
+- **Percentiles for latency, windows for SLOs.** Single-number latency hides the worst experience; an SLO without a measurement window is not enforceable.
+
+### Scope
+- **Contract of constraints, not design.** This file says *what* must be true, not *how* to satisfy it. Architecture, framework choice, and infrastructure topology belong in engineering design docs.
+- **Non-functional and platform.** Performance, scale, reliability, security, privacy, integrations, platforms, accessibility, localization, observability, cost. Functional behavior belongs in FRDs.
+- **No invention.** If a target is unknown, mark it as open with an owner and date: do not fabricate a number that will be treated as committed.
+
+## Good vs Bad Example
+
+**Good**
+
+```
+## Performance
+| User action | Metric | Target | Conditions |
+|-------------|--------|--------|------------|
+| Open Coaching Inbox | p95 latency | < 800 ms | desktop Chrome, fiber; US-East region |
+| Save call note | p95 latency | < 1.5 s | mobile web, LTE; user already authenticated |
+
+## Reliability & availability
+- SLO: 99.9% availability for Save Call Note, measured over rolling 30 days.
+- Error budget: 43.2 min / 30 days; freeze deploys on > 50% burn.
+- RTO 30 min, RPO 5 min for Salesforce Bridge.
+
+## Security
+- Authentication: SSO via Okta OIDC; session 12h, refresh 30 days.
+- Authorization: role-based: AE (own deals), Manager (team deals), Admin (org).
+- Data classification: notes are Restricted (may contain customer PII).
+
+## Privacy & compliance
+- Regimes: SOC 2 Type II (annual), GDPR for EU tenants, CCPA for California users.
+- Retention: call notes retained 7 years to match Salesforce; deletion request honored within 30 days per GDPR Art. 17.
+
+## Explicit non-constraints
+- Localization: English only at launch; not a constraint until EU expansion (Q3 2026).
+- Offline behavior: not supported in v1; AE is online by job definition.
+```
+
+**Bad**
+
+```
+## Performance
+- Should be fast.
+
+## Reliability & availability
+- Should be highly available.
+
+## Security
+- Should follow best practices.
+
+## Privacy & compliance
+- Should be compliant.
+
+## Localization
+- Should support multiple languages.
+```
+
+The bad version is unfalsifiable: engineering cannot design against any of it, and the team has no shared bar to evaluate the result. Every line is an adjective that means whatever the reader wants.
+
+## Anti-Patterns to Reject
+
+- Adjectives without numbers ("fast", "scalable", "secure").
+- One latency number for the whole system rather than per user action.
+- SLOs without a measurement window.
+- "Follows best practices" instead of naming the standard.
+- Silently skipping a category: if it doesn't apply, say so explicitly.
+
+## Allowed Tools
+
+- **AskUserQuestion**: drive discovery and resolve `projectid`
+- **Read**: load the existing file if it exists, to decide replace vs refine
+- **Write**: write the file

--- a/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/assets/technical-requirements-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/assets/technical-requirements-template.md
@@ -1,0 +1,65 @@
+# Technical Requirements
+
+- **Project:** {projectid}
+- **Last updated:** <YYYY-MM-DD>
+
+## Performance
+| User action | Metric | Target | Conditions |
+|-------------|--------|--------|------------|
+| <action> | p95 latency | <ms> | <hardware / network> |
+
+## Scale
+- Launch: <users / tenants / events>
+- 12 months: <users / tenants / events>
+- Peak vs steady-state: <ratio>
+
+## Reliability & availability
+- SLO: <99.x%> over <window>
+- RTO / RPO: <values>
+- Degradation: <what still works when X fails>
+
+## Security
+- Authentication: <method>
+- Authorization: <model>
+- Data classification: <input / output sensitivity>
+- Threat model concerns: <list>
+
+## Privacy & compliance
+- Regimes: <GDPR / HIPAA / SOC 2 / PCI / regional>
+- Sensitive data: <handling rules>
+- Retention / deletion: <rules>
+- Audit logging: <scope>
+
+## Integrations
+| System | Direction | Contract | Failure semantics |
+|--------|-----------|----------|-------------------|
+| <name> | in / out | <API / event / file> | <retry / dead-letter / fail-open> |
+
+## Platforms & environments
+- Supported: <browsers / OS / device>
+- Minimums: <hardware / network>
+- Deployment: <cloud / on-prem / hybrid>
+- Offline behavior: <expected>
+
+## Accessibility
+- Standard: <WCAG level>
+- Required behaviors: <keyboard / SR / contrast / motion>
+
+## Localization
+- Languages at launch: <list>
+- Languages within 12 months: <list>
+- RTL: <yes / no>
+- Formats: <dates / numbers / currency / time zones>
+
+## Observability
+- Logs: <required fields>
+- Metrics: <named SLIs>
+- Traces: <required spans>
+- Dashboards / alerts required before GA: <list>
+
+## Cost constraints
+- Unit cost target: <per user / request / event>
+- Infrastructure ceiling: <amount>
+
+## Explicit non-constraints
+- <category>: not a constraint for this product because <reason>

--- a/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/assets/technical-requirements-template.md
+++ b/plugins/trogonstack-product-requirements/skills/prd-technical-requirements/assets/technical-requirements-template.md
@@ -4,6 +4,7 @@
 - **Last updated:** <YYYY-MM-DD>
 
 ## Performance
+
 | User action | Metric | Target | Conditions |
 |-------------|--------|--------|------------|
 | <action> | p95 latency | <ms> | <hardware / network> |
@@ -31,6 +32,7 @@
 - Audit logging: <scope>
 
 ## Integrations
+
 | System | Direction | Contract | Failure semantics |
 |--------|-----------|----------|-------------------|
 | <name> | in / out | <API / event / file> | <retry / dead-letter / fail-open> |

--- a/plugins/trogonstack-product-requirements/skills/requirements-operating-model/SKILL.md
+++ b/plugins/trogonstack-product-requirements/skills/requirements-operating-model/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: requirements-operating-model
+description: >-
+  Apply the shared Requirements operating model across product-requirements
+  skills: Requirements / Blueprints / Work Orders boundaries,
+  single source-of-truth ownership, TrogonStack ask-question-compatible
+  clarification, Product Overview / FRD scope, feature hierarchy, and
+  downstream impact. Use alongside PRD or FRD writing, review, split, or
+  getting-started work when cross-document consistency, ambiguity, or module
+  handoff matters.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Glob
+  - Grep
+---
+
+# Requirements Operating Model
+
+Use this skill alongside Product Overview and Feature Requirements skills when the work depends on shared requirements context rather than one document's local template.
+
+## Module Boundaries
+
+The product development flow separates work into three document modules:
+
+- **Requirements** define what to build and why. Product Overview Documents describe the whole product. Feature Requirements Documents describe individual features. Requirements owns the feature hierarchy.
+- **Blueprints** define high-level architecture and design. Feature blueprints map to features; container blueprints describe deployable units; component blueprints describe reusable cross-cutting capabilities. Requirements may read them for context, but must not write blueprint content.
+- **Work Orders** define implementable delivery slices, sequenced planning phases, and execution scope. Requirements may read them for context, but must not create or rewrite work orders.
+
+When the user asks for architecture, code links, implementation sequencing, phase planning, technical-layer slicing, file-scope planning, duplicate work-order review, or work-order extraction, keep the requirement document focused and identify the downstream module that owns that work.
+
+## Skill Routing
+
+Route work to the narrowest requirements skill:
+
+- Product Overview scaffolding: `prd-getting-started`.
+- Product Overview section writing: the matching `prd-*` section skill.
+- Product Overview review: `prd-review`.
+- Initial Feature Requirements set: `frd-getting-started`.
+- Single FRD writing or refinement: `frd-write`.
+- Feature hierarchy changes, split, merge, or nesting: `frd-split`.
+- FRD or FRD tree review: `frd-review`.
+
+Use `ask-question` for clarification when it is available, while keeping product-requirements-specific judgment in these skills. Use code evidence only to understand current behavior or drift; architecture and code-link documentation belongs to Blueprints.
+
+When source material names older generic skills, map them to the current narrow skills instead of preserving the old names: feature creation maps to `frd-getting-started` or `frd-write`; generic Q&A maps to `ask-question`; feature organization maps to `frd-split`; document review maps to `prd-review` or `frd-review`; code search maps to code evidence for current behavior or drift.
+
+## Source Of Truth
+
+Every fact should have one authoritative home.
+
+- Product-wide motivation, current state, personas, product shape, success metrics, and technical constraints belong in Product Overview Documents.
+- Feature-specific user value, terminology, user stories, and acceptance criteria belong in FRDs.
+- Architecture decisions, runtime components, interfaces, and code links belong in Blueprints.
+- Developer tasks, phases, file-level implementation scope, and verbatim copied requirements belong in Work Orders.
+
+Before creating or restating content, search the relevant existing documents. If the fact already exists, reference it or refine the owning document instead of duplicating it.
+
+## Conversation Context
+
+Use the provided context as the map for requirement work:
+
+- Use the table of contents to understand available documents, document types, hierarchy, and parent-child relationships before changing structure.
+- Treat the current document as the default target when the user does not name another document.
+- Read attached artifacts before using them as evidence. Artifacts can ground requirements, but they do not override the authoritative owning document unless the user explicitly says they should.
+
+## Task Discipline
+
+Keep requirement edits grounded and scoped:
+
+- Understand the user's goal and the current state of relevant documents before changing content. Surface stale content, ambiguous decisions, or missing upstream documents before proceeding.
+- Read the target document before modifying it. For hierarchy, cross-document, or source-of-truth changes, read the affected neighboring documents too.
+- Ground new content in existing documents, project context, artifacts, code evidence, or direct user input. If a fact is unavailable, ask rather than invent.
+- Match the edit size to the request. A small correction should not trigger cleanup, restructuring, or new sections unless the user asked for that larger change.
+- If the request is specific and the target is clear, make the edit directly after reading context. If scope, behavior, source of truth, or multi-document impact is ambiguous, ask first.
+- Confirm before changes that affect multiple documents or project structure, even when the likely edit path is clear.
+- When a blueprint-to-code relationship is unclear, ask before using code evidence to change requirement content.
+- Reference work orders with the format `WO-XX: Title`. Requirements skills may identify downstream follow-up, but should not create bug reports, tickets, or work orders unless a downstream skill explicitly owns that action.
+
+## User-Facing Communication
+
+Keep responses direct and human-readable:
+
+- Lead with the answer, action, or decision. Keep explanations to the context needed for understanding.
+- Focus status updates on decisions needing input, natural milestones, and issues found while reading context.
+- Avoid restating the user's request unless it prevents ambiguity.
+- Explain findings, decisions, and completed edits rather than internal mechanics.
+- Refer to documents, blueprints, work orders, and artifacts by human-readable name. Do not expose internal IDs in user-facing text unless the user asks for them or they are needed to disambiguate a target.
+- Address the user directly.
+- Do not use emojis in responses or requirement documents.
+
+## Writing Quality
+
+Write requirements in plain language for technical and non-technical stakeholders:
+
+- Use active voice, concrete nouns, and named actors.
+- Avoid vague promotional adjectives such as "seamless", "powerful", "comprehensive", "sophisticated", and "engaging". Replace them with observable facts or measurable outcomes.
+- Requirements describe what the product or system must do and why. Implementation details belong in Blueprints; delivery tasks belong in Work Orders.
+- Do not prescribe UI layouts unless the user is explicitly defining a user-facing layout requirement. Prefer observable behavior, constraints, states, and outcomes.
+- Product Overview Documents should read like executive-summary narrative prose, not terse bullet collections. Use complete paragraphs that explain the motivation, current state, gaps, value proposition, expected outcomes, and relationship to the overall product vision before the reader opens feature-level documents.
+
+## Clarification Pattern
+
+Prefer the TrogonStack `ask-question` skill when it is available. It owns the generic interview loop. Product Requirements skills own the domain judgment about what must be clarified.
+
+If `ask-question` is not available, use the same lightweight pattern directly:
+
+```markdown
+**Question:** <one question>
+**Intention:** <why this answer changes the requirement work>
+**Assumptions:**
+- <current assumption>
+- <another assumption, if useful>
+```
+
+Ask one question at a time. Do not pre-plan or display a fixed question count. Treat each answer as new context: skip resolved questions, go deeper on new uncertainty, and push back when an answer conflicts with the requirements model.
+
+Ask before editing when scope, behavior, source of truth, or multi-document impact is ambiguous. If the request is specific and the target document is clear, act directly after reading the relevant context.
+
+## Product Overview Documents
+
+Product Overview Documents capture product-level why and what. The default set is:
+
+- `business-problem.prd.md`
+- `current-state.prd.md`
+- `personas.prd.md`
+- `product-description.prd.md`
+- `success-metrics.prd.md`
+- `technical-requirements.prd.md`
+
+Custom overview documents are allowed when a product-level context area does not fit the default set. They must name their scope, owner/source, relationship to defaults, and the overlap they intentionally avoid. Do not let custom documents become miscellaneous buckets for feature behavior, architecture, or delivery tasks.
+
+Product Overview Documents may be organized in their own hierarchy, separate from the feature tree. Do not treat Product Overview hierarchy changes as feature hierarchy changes.
+
+## Feature Requirements Documents
+
+Each FRD describes one feature. A feature is a cohesive, independently deliverable slice of user-facing value. When a feature has a corresponding feature blueprint, the FRD and blueprint should share the same human-readable title so downstream work can trace the same product slice across modules.
+
+Use this feature hierarchy rule:
+
+- A parent feature must deliver value without any child feature.
+- A child feature extends the parent but is meaningless without it.
+- If removing the child breaks the parent, it is not a child. Merge it into the parent or make it a top-level feature.
+- Feature nesting can go deeper than one level, but every level must satisfy the same parent-value and child-dependence rule.
+- Requirements skills own feature hierarchy changes. Do not move hierarchy ownership into Blueprints or Work Orders.
+
+FRDs use the base sections `Overview`, `Terminology`, and `Requirements`. Cross-requirement behavior, defaults, constraints, precedence, and edge conditions should usually become explicit acceptance criteria. Only add extension sections when the project template or the document structure needs them; `Child FRDs` is the standard built-in extension for parent documents with children.
+
+## Evidence And Traceability
+
+Use artifacts, code, and downstream documents as context without moving their ownership into Requirements:
+
+- **Artifacts** are user-provided context such as meeting notes, research, or designs. Read them when available and ground claims in them, but do not invent facts they do not support.
+- **Code** captures current implementation state. Requirements can use code evidence to understand current behavior or drift, while Blueprints remain the owner for target architecture and code links. If context includes code chunks or code links, treat them as Blueprint-owned traceability and do not maintain them from Requirements.
+- **Work Orders** should trace back to requirements and blueprints. They may contain verbatim requirement excerpts and names of source blueprints that inform implementation. If a requirements change affects copied requirement text, implementation scope, or source traceability, flag the downstream follow-up instead of editing work orders.
+- **Links and mentions** establish cross-document relationships. Prefer human-readable markdown links or document mentions when referencing related requirements, blueprints, work orders, or artifacts.
+
+## Forward And Reverse Flow
+
+The default product development flow is Requirements to Blueprints to Work Orders. Requirements should establish intent before architecture and delivery planning depend on it.
+
+Work orders may exist before requirements or blueprints are final, but requirement work should mark the upstream documentation that still needs finalization before implementation starts. Do not treat early work-order text as the source of truth when it conflicts with requirements intent.
+
+Use reverse-engineering work when the user wants to document an existing system:
+
+- **Initial documentation** should produce requirements that accurately reflect the system as it exists today.
+- **Drift detection** should identify mismatches between existing requirements and the current implementation.
+
+Once reverse-engineered documents are accepted, treat them as the baseline for future forward work. If later requirements changes invalidate blueprint or work-order assumptions, flag the downstream follow-up explicitly.
+
+## Context Reading
+
+Read upstream context before writing:
+
+- Business Problem should be grounded in user input, evidence, artifacts, or existing project context.
+- Current State should align with Business Problem and describe the baseline before change.
+- Personas should inform Product Description, Success Metrics, and FRD user stories.
+- Product Description should be grounded in Business Problem, Current State, and Personas.
+- Success Metrics should connect Business Problem, Current State costs, and Persona success.
+- Technical Requirements should constrain the build without becoming a blueprint.
+- FRDs should read relevant Product Overview Documents and nearby FRDs before adding requirements.
+
+## Downstream Impact
+
+Requirements changes may invalidate Blueprints or Work Orders. Review and restructuring skills should flag likely downstream impact without editing downstream modules.
+
+Call out impact when a change:
+
+- changes feature boundaries or hierarchy
+- changes user stories or acceptance criteria used by engineering
+- changes personas, product surfaces, metrics, or technical constraints
+- removes or renames a requirement ID
+- contradicts a blueprint, work order, artifact, or current code evidence
+- reveals a reusable capability shared by multiple features, a capability being abstracted, or enough internal structure to warrant a downstream Component Blueprint review
+
+Do not recommend a Component Blueprint for a single utility with no internal structure or logic that only belongs to one feature. Components may start inside Feature Blueprints and migrate to Component Blueprints when reuse across features emerges; Requirements should flag that possibility without creating or rewriting blueprint content.


### PR DESCRIPTION
- Product and feature authors need a shared structure so engineers, reviewers, and AI agents can pick up requirements work without losing intent or duplicating context.
- A dedicated plugin keeps PRD and FRD authoring decoupled from blueprints and work orders, matching the rest of the TrogonStack skill catalog.